### PR TITLE
fix: Reference argv and prog consistently.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.8.2
+
+- The command's name should now always translate to the prog name
+- Explicitly provided argv should now **not** include the prog name
+
+## 0.8.1
+
+- Correct the version long name when long=True.
+
 ## 0.8.0
 
 - Implement support for PEP-727 help text inference.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,13 @@
 [tool.poetry]
 name = "cappa"
-version = "0.8.1"
+version = "0.8.2"
 description = ""
 authors = ["DanCardin <ddcardin@gmail.com>"]
 readme = "README.md"
 packages = [{include = "cappa", from = "src"}]
+
+[tool.poetry.scripts]
+meow = "cappa.meow:run"
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/src/cappa/argparse.py
+++ b/src/cappa/argparse.py
@@ -137,7 +137,7 @@ def backend(
     ns = Nestedspace()
 
     try:
-        result_namespace = parser.parse_args(argv[1:], ns)
+        result_namespace = parser.parse_args(argv, ns)
     except argparse.ArgumentError as e:
         raise Exit(str(e), code=2)
 
@@ -156,7 +156,7 @@ def create_parser(
         kwargs["exit_on_error"] = False
 
     parser = ArgumentParser(
-        prog=command.name,
+        prog=command.real_name(),
         description=join_help(command.help, command.description),
         allow_abbrev=False,
         add_help=False,

--- a/src/cappa/base.py
+++ b/src/cappa/base.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import dataclasses
-import sys
 import typing
 
 from rich.theme import Theme
@@ -54,9 +53,6 @@ def parse(
             the argument's behavior.
         theme: Optional rich theme to customized output formatting.
     """
-    if argv is None:  # pragma: no cover
-        argv = sys.argv
-
     command = Command.get(obj)
 
     output = Output.from_theme(theme)
@@ -113,9 +109,6 @@ def invoke(
             the argument's behavior.
         theme: Optional rich theme to customized output formatting.
     """
-    if argv is None:  # pragma: no cover
-        argv = sys.argv
-
     command: Command = Command.get(obj)
 
     output = Output.from_theme(theme)

--- a/src/cappa/command.py
+++ b/src/cappa/command.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import inspect
+import sys
 import typing
 from collections.abc import Callable
 
@@ -66,9 +67,9 @@ class Command(typing.Generic[T]):
         if self.name is not None:
             return self.name
 
-        cls_name = self.cmd_cls.__name__
         import re
 
+        cls_name = self.cmd_cls.__name__
         return re.sub(r"(?<!^)(?=[A-Z])", "-", cls_name).lower()
 
     @classmethod
@@ -120,7 +121,7 @@ class Command(typing.Generic[T]):
         cls,
         command: Command[T],
         *,
-        argv: list[str],
+        argv: list[str] | None = None,
         output: Output,
         backend: typing.Callable | None = None,
         color: bool = True,
@@ -128,6 +129,9 @@ class Command(typing.Generic[T]):
         help: bool | Arg = True,
         completion: bool | Arg = True,
     ) -> tuple[Command, Command[T], T]:
+        if argv is None:  # pragma: no cover
+            argv = sys.argv[1:]
+
         command = cls.collect(command)
 
         if backend is None:  # pragma: no cover

--- a/src/cappa/completion/base.py
+++ b/src/cappa/completion/base.py
@@ -32,7 +32,7 @@ def execute(
 
     backend(
         command,
-        [prog, *command_args],
+        command_args,
         version=version,
         help=help,
         provide_completions=True,

--- a/src/cappa/completion/types.py
+++ b/src/cappa/completion/types.py
@@ -14,11 +14,6 @@ class ShellHandler:
     template: str
 
     def backend_template(self, prog: str, arg: Arg) -> str:
-        try:
-            prog, _ = prog.rsplit("/", 1)
-        except ValueError:
-            pass
-
         safe_name = re.sub(r"\W*", "", prog.replace("-", "_"), flags=re.ASCII)
 
         assert isinstance(arg.long, list)

--- a/src/cappa/parser.py
+++ b/src/cappa/parser.py
@@ -55,10 +55,7 @@ def backend(
     if not color:
         os.environ["NO_COLOR"] = "1"
 
-    try:
-        prog, *argv = argv
-    except ValueError:
-        prog = ""
+    prog = command.real_name()
 
     args = RawArg.collect(argv, provide_completions=provide_completions)
 

--- a/src/cappa/testing.py
+++ b/src/cappa/testing.py
@@ -56,7 +56,7 @@ class CommandRunner:
 
         Or create a runner that always uses the same base CLI object, and default base command
 
-        >>> runner = CommandRunner(Obj, base_args=['command', 'first'])
+        >>> runner = CommandRunner(Obj, base_args=['first'])
 
         Now each test, can customize the behavior to suit the test in question.
 
@@ -74,7 +74,7 @@ class CommandRunner:
     version: str | cappa.Arg | None = None
     help: bool | cappa.Arg = True
 
-    base_args: list[str] = field(default_factory=lambda: ["command"])
+    base_args: list[str] = field(default_factory=lambda: [])
 
     def coalesce_args(self, *args: str, **kwargs: Unpack[RunnerArgs]) -> dict:
         return {

--- a/tests/completion/test_base.py
+++ b/tests/completion/test_base.py
@@ -33,7 +33,7 @@ def test_generate_completions():
 
     assert e.value.code == 0
     assert e.value.message
-    assert "_testpy_completion" in str(e.value.message)
+    assert "_args_completion" in str(e.value.message)
 
 
 def test_invalid_setup():
@@ -59,7 +59,7 @@ def test_no_completion():
     with pytest.raises(cappa.Exit) as e:
         cappa.parse(
             Example,
-            argv=["ex", "--completion", "generate"],
+            argv=["--completion", "generate"],
             backend=backend,
             completion=False,
         )
@@ -79,19 +79,19 @@ def test_arg_completion(capsys):
     with pytest.raises(SystemExit) as e:
         cappa.parse(
             Example,
-            argv=["ex", "-p", "generate"],
+            argv=["-p", "generate"],
             completion=completion,
             backend=backend,
         )
     assert e.value.code == 0
 
     out = capsys.readouterr().out
-    assert "_ex_completion" in out
+    assert "_example_completion" in out
 
     with pytest.raises(SystemExit) as e:
         cappa.parse(
             Example,
-            argv=["ex", "--help"],
+            argv=["--help"],
             completion=completion,
             backend=backend,
         )

--- a/tests/parser/test_custom_callable_action.py
+++ b/tests/parser/test_custom_callable_action.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Union
+
+import cappa
+from typing_extensions import Annotated
+
+from tests.utils import backends, parse
+
+
+@backends
+def test_callable_action_fast_exit(backend):
+    @dataclass
+    class Args:
+        foo: str
+        raw: Annotated[Union[List[str], None], cappa.Arg(num_args=-1)] = None
+
+    test = parse(Args, "foovalue", "--", "--raw", "value", backend=backend)
+    assert test.foo == "foovalue"
+    assert test.raw == ["--raw", "value"]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -29,11 +29,11 @@ def test_no_help(backend):
     assert result == Example()
 
     with pytest.raises(SystemExit) as e:
-        cappa.parse(Example, argv=["ex", "-h"], help=False, backend=backend)
+        cappa.parse(Example, argv=["-h"], help=False, backend=backend)
     assert e.value.code == 2
 
     with pytest.raises(SystemExit) as e:
-        cappa.parse(Example, argv=["ex", "--help"], help=False, backend=backend)
+        cappa.parse(Example, argv=["--help"], help=False, backend=backend)
     assert e.value.code == 2
 
 
@@ -50,14 +50,14 @@ def test_arg_help(capsys, backend):
     assert result == Example()
 
     with pytest.raises(SystemExit) as e:
-        cappa.parse(Example, argv=["ex", "-p"], help=help, backend=backend)
+        cappa.parse(Example, argv=["-p"], help=help, backend=backend)
     assert e.value.code == 0
 
     out = capsys.readouterr().out
     assert "-p, --pelp" in out
 
     with pytest.raises(SystemExit) as e:
-        cappa.parse(Example, argv=["ex", "--pelp"], help=help, backend=backend)
+        cappa.parse(Example, argv=["--pelp"], help=help, backend=backend)
     assert e.value.code == 0
 
     out = capsys.readouterr().out
@@ -71,7 +71,7 @@ def test_version_enabled(capsys, backend):
         ...
 
     with pytest.raises(SystemExit) as e:
-        cappa.parse(Example, argv=["ex", "--version"], version="1.2.3", backend=backend)
+        cappa.parse(Example, argv=["--version"], version="1.2.3", backend=backend)
     assert e.value.code == 0
 
     out = capsys.readouterr().out
@@ -90,14 +90,14 @@ def test_arg_version(capsys, backend):
     assert result == Example()
 
     with pytest.raises(SystemExit) as e:
-        cappa.parse(Example, argv=["ex", "-p"], version=version, backend=backend)
+        cappa.parse(Example, argv=["-p"], version=version, backend=backend)
     assert e.value.code == 0
 
     out = capsys.readouterr().out
     assert "1.2.3" in out
 
     with pytest.raises(SystemExit) as e:
-        cappa.parse(Example, argv=["ex", "--persion"], version=version, backend=backend)
+        cappa.parse(Example, argv=["--persion"], version=version, backend=backend)
     assert e.value.code == 0
 
     out = capsys.readouterr().out
@@ -123,7 +123,7 @@ def test_arg_explicit_version_missing_name(backend):
     version: cappa.Arg = cappa.Arg(short="-p", long="--persion")
 
     with pytest.raises(ValueError) as e:
-        cappa.parse(Example, argv=["ex", "-p"], version=version, backend=backend)
+        cappa.parse(Example, argv=["-p"], version=version, backend=backend)
 
     assert (
         str(e.value)
@@ -140,7 +140,20 @@ def test_arg_explicit_version_long_true_defaults_to_version(capsys, backend):
     version: cappa.Arg = cappa.Arg("1.2.3", short="-p", long=True)
 
     with pytest.raises(cappa.Exit):
-        cappa.parse(Example, argv=["ex", "--version"], version=version, backend=backend)
+        cappa.parse(Example, argv=["--version"], version=version, backend=backend)
 
     out = capsys.readouterr().out
     assert "1.2.3" in out
+
+
+@backends
+def test_prog_basename(capsys, backend):
+    @dataclass
+    class Example:
+        ...
+
+    with pytest.raises(cappa.Exit):
+        cappa.parse(Example, argv=["--help"], backend=backend)
+
+    out = capsys.readouterr().out
+    assert "usage: example" in out.lower()

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -17,7 +17,7 @@ def test_invoke_exit_success_with_message(capsys, backend):
         ...
 
     with pytest.raises(cappa.Exit):
-        cappa.invoke(Example, argv=[""], backend=backend)
+        cappa.invoke(Example, argv=[], backend=backend)
 
     out = capsys.readouterr().out
     assert out == "With message\n"
@@ -34,7 +34,7 @@ def test_invoke_exit_success_without_message(capsys, backend):
         ...
 
     with pytest.raises(cappa.Exit):
-        cappa.invoke(Example, argv=[""], backend=backend)
+        cappa.invoke(Example, argv=[], backend=backend)
 
     out = capsys.readouterr().out
     assert out == ""
@@ -51,7 +51,7 @@ def test_invoke_exit_errror(capsys, backend):
         ...
 
     with pytest.raises(cappa.Exit) as e:
-        cappa.invoke(Example, argv=[""], backend=backend)
+        cappa.invoke(Example, argv=[], backend=backend)
 
     assert e.value.code == 1
     out = capsys.readouterr().err

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,7 +8,7 @@ from cappa.testing import CommandRunner
 
 backends = pytest.mark.parametrize("backend", [None, backend])
 
-runner = CommandRunner(base_args=["test.py"])
+runner = CommandRunner(base_args=[])
 
 
 def parse(cls, *args, backend=None):


### PR DESCRIPTION
* The command's name should now always translate to the prog name
* Explicitly provided argv should now **not** include the prog name

Fixes https://github.com/DanCardin/cappa/issues/14