### PR TITLE
Fix help of the completion argument

### DIFF
--- a/src/cappa/help.py
+++ b/src/cappa/help.py
@@ -62,13 +62,13 @@ def create_completion_arg(completion: bool | Arg = True) -> Arg | None:
         return None
 
     if isinstance(completion, bool):
-        completion = Arg(
+        return Arg(
             name="completion",
             long=["--completion"],
             choices=["generate", "complete"],
             group=(3, "Help"),
-            help="Use `--completion generate` to print shell-specific completion source",
-        ).normalize()
+            help="Use `--completion generate` to print shell-specific completion source.",
+        ).normalize(action=ArgAction.completion)
 
     return completion.normalize(action=ArgAction.completion)
 

--- a/tests/help/test_completion_choices.py
+++ b/tests/help/test_completion_choices.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+import cappa
+import pytest
+
+from tests.utils import parse
+
+
+def test_string_group(capsys):
+    @dataclass
+    class Args:
+        ...
+
+    with pytest.raises(cappa.HelpExit) as e:
+        parse(Args, "--help", backend=cappa.backend)
+
+    assert e.value.code == 0
+
+    out = capsys.readouterr().out
+
+    options = re.findall(r"Valid\s+options:\s+generate,\s+complete", out, re.MULTILINE)
+    assert len(options) == 1


### PR DESCRIPTION
Point 4 of the main command in #15.
Previous code was normalizing the argument twice, therefore appending the choices to the help message twice.