### PR TITLE
fix: Literal["one", "two"] syntax as choices.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.8.3
+
+- Fix `Literal["one", "two"]` syntax vs `Literal["one"] | Literal["two"]`
+- Apply custom completions to already "valid" arguments values
+- Deduplicate the --completion helptext choices
+
 ## 0.8.2
 
 - The command's name should now always translate to the prog name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cappa"
-version = "0.8.2"
+version = "0.8.3"
 description = ""
 authors = ["DanCardin <ddcardin@gmail.com>"]
 readme = "README.md"

--- a/src/cappa/command.py
+++ b/src/cappa/command.py
@@ -160,12 +160,6 @@ class Command(typing.Generic[T]):
         for arg in self.value_arguments():
             is_subcommand = isinstance(arg, Subcommand)
             if arg.name not in parsed_args:
-                # if arg.required:
-                #     raise Exit(
-                #         f"The following arguments are required: {arg.names_str()}",
-                #         code=1,
-                #     )
-
                 if is_subcommand:
                     continue
 

--- a/src/cappa/parser.py
+++ b/src/cappa/parser.py
@@ -383,7 +383,9 @@ def consume_arg(
 
             if context.provide_completions and not context.has_values():
                 if arg.completion:
-                    completions = arg.completion(result)
+                    completions: list[Completion] | list[
+                        FileCompletion
+                    ] = arg.completion(result)
                 else:
                     completions = [FileCompletion(result)]
                 raise CompletionError(*completions)

--- a/src/cappa/parser.py
+++ b/src/cappa/parser.py
@@ -382,7 +382,11 @@ def consume_arg(
                 )
 
             if context.provide_completions and not context.has_values():
-                raise CompletionError(FileCompletion(result))
+                if arg.completion:
+                    completions = arg.completion(result)
+                else:
+                    completions = [FileCompletion(result)]
+                raise CompletionError(*completions)
         else:
             if not option and not arg.required:
                 return

--- a/tests/arg/test_literal_mulitple_variant.py
+++ b/tests/arg/test_literal_mulitple_variant.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import cappa
+import pytest
+
+from tests.utils import backends, parse
+
+
+@dataclass
+class ArgTest:
+    name: Literal["one", "two", "three", 4]
+
+
+@backends
+def test_literal(backend):
+    test = parse(ArgTest, "two", backend=backend)
+    assert test.name == "two"
+
+    test = parse(ArgTest, "4", backend=backend)
+    assert test.name == 4
+
+    with pytest.raises(cappa.Exit) as e:
+        parse(ArgTest, "thename", backend=backend)
+
+    message = str(e.value.message).lower()
+    assert (
+        "invalid choice: 'thename' (choose from 'one', 'two', 'three', '4')" in message
+    )

--- a/tests/completion/test_custom_completion.py
+++ b/tests/completion/test_custom_completion.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, Union
 
 import cappa
 from typing_extensions import Annotated

--- a/tests/completion/test_custom_completion.py
+++ b/tests/completion/test_custom_completion.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Union
+
+import cappa
+from typing_extensions import Annotated
+
+from tests.utils import parse_completion
+
+
+def foo(f: str):
+    return [cappa.Completion(f"{f}ooooo", "ok")]
+
+
+def test_custom_completion():
+    @dataclass
+    class Args:
+        value: Annotated[str, cappa.Arg(short=True, completion=foo)]
+
+    result = parse_completion(Args, "-v", "f")
+    assert result
+    assert result == "fooooo:ok"


### PR DESCRIPTION
Fixes https://github.com/DanCardin/cappa/issues/18