### PR TITLE
feat: Split name and field_name on Arg object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.10.0
+
+- Split Arg `name`/`field_name`. `name` controls help/error output naming.
+  `field_name` controls the the destination field on the dataclass object.
+
 ## 0.9.3
 
 - Ensure output of missing required options is deterministically ordered

--- a/docs/source/manual_construction.md
+++ b/docs/source/manual_construction.md
@@ -24,8 +24,8 @@ class Foo:
 command = cappa.Command(
     Foo,
     arguments=[
-        cappa.Arg(name="bar", parse=str),
-        cappa.Arg(name="baz", parse=parse_list(int), num_args=-1),
+        cappa.Arg(field_name="bar", parse=str),
+        cappa.Arg(field_name="baz", parse=parse_list(int), num_args=-1),
     ],
     help="Short help.",
     description="Long description.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cappa"
-version = "0.9.3"
+version = "0.10.0"
 description = "Declarative CLI argument parser."
 
 repository = "https://github.com/dancardin/cappa"

--- a/src/cappa/argparse.py
+++ b/src/cappa/argparse.py
@@ -13,7 +13,7 @@ from cappa.help import format_help, generate_arg_groups
 from cappa.invoke import fullfill_deps
 from cappa.output import Exit, HelpExit
 from cappa.parser import RawOption, Value
-from cappa.typing import assert_not_missing, assert_type, missing
+from cappa.typing import assert_type, missing
 
 if sys.version_info < (3, 9):  # pragma: no cover
     # Backport https://github.com/python/cpython/pull/3680
@@ -153,7 +153,7 @@ def backend(
             for a in command.arguments
             if isinstance(a, Arg) and a.action is ArgAction.version
         )
-        parser.version = version.name  # type: ignore
+        parser.version = version.value_name  # type: ignore
     except StopIteration:
         pass
 
@@ -210,8 +210,6 @@ def add_argument(
     dest_prefix="",
     **extra_kwargs,
 ):
-    name: str = assert_not_missing(arg.name)
-
     names: list[str] = []
     if arg.short:
         short = assert_type(arg.short, list)
@@ -226,9 +224,9 @@ def add_argument(
     num_args = backend_num_args(arg.num_args)
 
     kwargs: dict[str, typing.Any] = {
-        "dest": dest_prefix + name,
+        "dest": dest_prefix + arg.field_name,
         "help": arg.help,
-        "metavar": name,
+        "metavar": arg.value_name,
         "action": get_action(arg),
     }
 
@@ -260,7 +258,7 @@ def add_subcommands(
     subcommands: Subcommand,
     dest_prefix="",
 ):
-    subcommand_dest = subcommands.name
+    subcommand_dest = subcommands.field_name
     subparsers = parser.add_subparsers(
         title=group,
         required=assert_type(subcommands.required, bool),

--- a/src/cappa/command.py
+++ b/src/cappa/command.py
@@ -105,9 +105,7 @@ class Command(typing.Generic[T]):
                 type_hint = type_hints[field.name]
                 arg_help = arg_help_map.get(field.name)
 
-                maybe_subcommand = Subcommand.collect(
-                    field, type_hint, fallback_help=arg_help
-                )
+                maybe_subcommand = Subcommand.collect(field, type_hint)
                 if maybe_subcommand:
                     arguments.append(maybe_subcommand)
                 else:
@@ -143,13 +141,13 @@ class Command(typing.Generic[T]):
         kwargs = {}
         for arg in self.value_arguments():
             is_subcommand = isinstance(arg, Subcommand)
-            if arg.name not in parsed_args:
+            if arg.field_name not in parsed_args:
                 if is_subcommand:
                     continue
 
                 value = arg.default
             else:
-                value = parsed_args[arg.name]
+                value = parsed_args[arg.field_name]
 
             if isinstance(value, Env):
                 value = value.evaluate()
@@ -170,7 +168,7 @@ class Command(typing.Generic[T]):
                         code=2,
                     )
 
-            kwargs[arg.name] = value
+            kwargs[arg.field_name] = value
 
         return command.cmd_cls(**kwargs)
 

--- a/src/cappa/invoke.py
+++ b/src/cappa/invoke.py
@@ -139,7 +139,7 @@ def resolve_implicit_deps(command: Command, instance: HasCommand) -> dict:
             # Args do not produce dependencies themselves.
             continue
 
-        option_instance = getattr(instance, arg.name)
+        option_instance = getattr(instance, arg.field_name)
         if option_instance is None:
             # None is a valid subcommand instance value, but it wont exist as a dependency
             # where an actual command has been selected.

--- a/src/cappa/parser.py
+++ b/src/cappa/parser.py
@@ -82,7 +82,7 @@ def backend(
         except HelpAction as e:
             raise HelpExit(format_help(e.command, e.command_name), code=0)
         except VersionAction as e:
-            raise Exit(e.version.name, code=0)
+            raise Exit(e.version.value_name, code=0)
         except BadArgumentError as e:
             if context.provide_completions and e.arg:
                 completions = e.arg.completion(e.value) if e.arg.completion else []
@@ -146,8 +146,8 @@ class ParseContext:
 
             if arg.short or arg.long:
                 if arg.action not in ArgAction.value_actions():
-                    unique_names.add(arg.name)
-                result[arg.name] = arg
+                    unique_names.add(arg.field_name)
+                result[arg.field_name] = arg
 
             assert arg.short is not True
             for short in arg.short or []:
@@ -426,7 +426,7 @@ def consume_subcommand(context: ParseContext, arg: Subcommand) -> typing.Any:
 
     parse(nested_context)
 
-    name = typing.cast(str, arg.name)
+    name = typing.cast(str, arg.field_name)
     context.result[name] = nested_context.result
 
 
@@ -491,14 +491,14 @@ def consume_arg(
                 return
 
             raise BadArgumentError(
-                f"Option '{arg.name}' requires an argument.",
+                f"Option '{arg.value_name}' requires an argument.",
                 value="",
                 command=context.command,
                 arg=arg,
             )
 
-    if option and arg.name in context.missing_options:
-        context.missing_options.remove(arg.name)
+    if option and arg.value_name in context.missing_options:
+        context.missing_options.remove(arg.value_name)
 
     action = arg.action
     assert action
@@ -518,7 +518,7 @@ def consume_arg(
         fullfilled_deps[RawOption] = option
 
     kwargs = fullfill_deps(action_handler, fullfilled_deps)
-    context.result[arg.name] = action_handler(**kwargs)
+    context.result[arg.value_name] = action_handler(**kwargs)
 
 
 @dataclasses.dataclass
@@ -539,7 +539,7 @@ def store_bool(val: bool):
 
 
 def store_count(context: ParseContext, arg: Arg):
-    return context.result.get(arg.name, 0) + 1
+    return context.result.get(arg.value_name, 0) + 1
 
 
 def store_set(value: Value[typing.Any]):
@@ -547,7 +547,7 @@ def store_set(value: Value[typing.Any]):
 
 
 def store_append(context: ParseContext, arg: Arg, value: Value[typing.Any]):
-    result = context.result.setdefault(arg.name, [])
+    result = context.result.setdefault(arg.value_name, [])
     result.append(value.value)
     return result
 

--- a/src/cappa/subcommand.py
+++ b/src/cappa/subcommand.py
@@ -34,7 +34,7 @@ class Subcommand:
         hidden: Whether the argument should be hidden in help text. Defaults to False.
     """
 
-    name: str | MISSING = ...
+    field_name: str | MISSING = ...
     required: bool | None = None
     group: str | tuple[int, str] = (3, "Subcommands")
     hidden: bool = False
@@ -43,9 +43,7 @@ class Subcommand:
     options: dict[str, Command] = dataclasses.field(default_factory=dict)
 
     @classmethod
-    def collect(
-        cls, field: Field, type_hint: type, fallback_help: str | None = None
-    ) -> Self | None:
+    def collect(cls, field: Field, type_hint: type) -> Self | None:
         object_annotation = find_type_annotation(type_hint, cls)
         subcommand = object_annotation.obj
 
@@ -61,17 +59,15 @@ class Subcommand:
 
         return subcommand.normalize(
             object_annotation.annotation,
-            name=field.name,
-            fallback_help=object_annotation.doc or fallback_help,
+            field_name=field.name,
         )
 
     def normalize(
         self,
         annotation=NoneType,
-        name: str | None = None,
-        fallback_help: str | None = None,
+        field_name: str | None = None,
     ) -> Self:
-        name = name or assert_type(self.name, str)
+        field_name = field_name or assert_type(self.field_name, str)
         types = infer_types(self, annotation)
         required = infer_required(self, annotation)
         options = infer_options(self, types)
@@ -79,7 +75,7 @@ class Subcommand:
 
         return dataclasses.replace(
             self,
-            name=name,
+            field_name=field_name,
             types=types,
             required=required,
             options=options,

--- a/src/cappa/typing.py
+++ b/src/cappa/typing.py
@@ -65,11 +65,6 @@ def find_type_annotation(
     return ObjectAnnotation(obj=instance, annotation=type_hint, doc=doc)
 
 
-def assert_not_missing(value: T | MISSING) -> T:
-    assert not isinstance(value, MISSING), value
-    return typing.cast(T, value)
-
-
 def assert_type(value: typing.Any, typ: type[T]) -> T:
     assert isinstance(value, typ), value
     return typing.cast(T, value)

--- a/tests/arg/test_help.py
+++ b/tests/arg/test_help.py
@@ -23,7 +23,7 @@ def test_explicit_parse_function(backend, capsys):
         parse(ArgTest, "--help", backend=backend)
 
     stdout = capsys.readouterr().out
-    assert re.match(r".*numbers\s+example.*", stdout, re.DOTALL)
+    assert re.match(r".*NUMBERS\s+example.*", stdout, re.DOTALL)
 
 
 @pytest.mark.help

--- a/tests/arg/test_name_disallowed.py
+++ b/tests/arg/test_name_disallowed.py
@@ -13,7 +13,7 @@ from tests.utils import backends, parse
 def test_arg_name_disallowed(backend):
     @dataclass
     class ArgTest:
-        bad: Annotated[bool, cappa.Arg(name="oops")] = False
+        bad: Annotated[bool, cappa.Arg(field_name="oops")] = False
 
     with pytest.raises(
         ValueError, match="Arg 'name' cannot be set when using automatic inference."

--- a/tests/help/test_group.py
+++ b/tests/help/test_group.py
@@ -22,4 +22,4 @@ def test_string_group(backend, capsys):
     assert e.value.code == 0
 
     out = capsys.readouterr().out
-    assert re.match(r".*Strings:?\s*\n\s*name.*", out, re.DOTALL)
+    assert re.match(r".*Strings:?\s*\n\s*NAME.*", out, re.DOTALL)

--- a/tests/help/test_name.py
+++ b/tests/help/test_name.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import textwrap
+from dataclasses import dataclass
+
+import cappa
+import pytest
+from typing_extensions import Annotated
+
+from tests.utils import parse
+
+
+def test_argument_name(capsys):
+    @dataclass
+    class Args:
+        name: Annotated[str, cappa.Arg(value_name="string name", help="more")]
+        short: Annotated[str, cappa.Arg(short=True, value_name="optional string")]
+
+    with pytest.raises(cappa.HelpExit) as e:
+        parse(Args, "--help")
+
+    assert e.value.code == 0
+
+    out = "\n".join([line.rstrip() for line in capsys.readouterr().out.split("\n")])
+
+    assert out == textwrap.dedent(
+        """\
+        Usage: args -s OPTIONAL-STRING STRING-NAME [-h] [--completion COMPLETION]
+
+          Options
+            -s OPTIONAL-STRING
+
+          Arguments
+            STRING-NAME                more
+
+          Help
+            [-h, --help]               Show this message and exit.
+            [--completion COMPLETION]  Use `--completion generate` to print
+                                       shell-specific completion source. Valid options:
+                                       generate, complete.
+
+        """
+    )

--- a/tests/test_docstring.py
+++ b/tests/test_docstring.py
@@ -30,9 +30,9 @@ def test_required_provided(backend, capsys):
 
     result = capsys.readouterr().out
 
-    assert "[--bar] foo [-h]" in result
+    assert "[--bar] FOO [-h]" in result
     assert re.match(r".*Does a thing\.\s+and does it really well!.*", result, re.DOTALL)
-    assert re.match(r".*foo\s+the value of foo.*", result, re.DOTALL)
+    assert re.match(r".*FOO\s+the value of foo.*", result, re.DOTALL)
     assert re.match(r".*\[--bar\]\s+whether to bar.*", result, re.DOTALL)
 
 

--- a/tests/test_manually_built.py
+++ b/tests/test_manually_built.py
@@ -18,8 +18,8 @@ class Foo:
 command = cappa.Command(
     Foo,
     arguments=[
-        cappa.Arg(name="bar", parse=str),
-        cappa.Arg(name="baz", parse=parse_list(int), num_args=-1),
+        cappa.Arg(field_name="bar", parse=str),
+        cappa.Arg(field_name="baz", parse=parse_list(int), num_args=-1),
     ],
     help="Short help.",
     description="Long description.",
@@ -57,12 +57,12 @@ def test_subcommand(backend):
         Foo,
         arguments=[
             cappa.Subcommand(
-                name="sub",
+                field_name="sub",
                 options={
                     "bar": cappa.Command(
                         Bar,
                         arguments=[
-                            cappa.Arg(name="bar", parse=parse_value),
+                            cappa.Arg(field_name="bar", parse=parse_value),
                         ],
                     )
                 },


### PR DESCRIPTION
Fix https://github.com/DanCardin/cappa/issues/46.

At current moment, `name` field is relatively inaccessible except for the "manual construction" usecase. It's otherwise able to be specified. Thus using such a valuable, generic name seemed unncessary. Thus `name` -> `field_name`.

~With `name` freed up, "name" seems like a decent name for the equivalent of `metavar` in argparse. I suppose `name` could be confused with short/long?~

I looked at Clap which uses [value_name](https://docs.rs/clap/latest/clap/struct.Arg.html#method.value_name), which i rather like, and which seems to me to pair well with `field_name`. certainly better than metavar