### PR TITLE
fix: Leave value_name formatting up to the user.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cappa"
-version = "0.10.0"
+version = "0.10.1"
 description = "Declarative CLI argument parser."
 
 repository = "https://github.com/dancardin/cappa"

--- a/src/cappa/help.py
+++ b/src/cappa/help.py
@@ -146,12 +146,12 @@ def format_arg_name(arg: Arg | Subcommand, delimiter, *, n=0) -> str:
 
         arg_names = arg.names_str(delimiter, n=n)
         if not is_option:
-            arg_names = arg_names.replace(" ", "-").upper()
+            arg_names = arg_names.upper()
 
         text = f"[cappa.arg]{arg_names}[/cappa.arg]"
 
         if is_option and has_value:
-            name = arg.value_name.replace(" ", "-").upper()
+            name = arg.value_name.upper()
             text = f"{text} [cappa.arg.name]{name}[/cappa.arg.name]"
 
         if not arg.required:

--- a/src/cappa/parser.py
+++ b/src/cappa/parser.py
@@ -518,7 +518,7 @@ def consume_arg(
         fullfilled_deps[RawOption] = option
 
     kwargs = fullfill_deps(action_handler, fullfilled_deps)
-    context.result[arg.value_name] = action_handler(**kwargs)
+    context.result[arg.field_name] = action_handler(**kwargs)
 
 
 @dataclasses.dataclass

--- a/tests/arg/test_value_name.py
+++ b/tests/arg/test_value_name.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Union
+
+import cappa
+from cappa import Subcommands
+from typing_extensions import Annotated
+
+from tests.utils import backends, parse
+
+
+@cappa.command(name="example")
+@dataclass
+class Example:
+    subcommand: Subcommands[Union[A, None]] = None
+
+
+@cappa.command(name="a")
+@dataclass
+class A:
+    a: Annotated[str, cappa.Arg(value_name="<Str a>", short="-a", required=False)]
+
+
+@backends
+def test_value_name_uses_correct_value(backend):
+    result = parse(Example, "a", "-a", "test", backend=backend)
+    assert result == Example(subcommand=A(a="test"))

--- a/tests/help/test_name.py
+++ b/tests/help/test_name.py
@@ -13,8 +13,8 @@ from tests.utils import parse
 def test_argument_name(capsys):
     @dataclass
     class Args:
-        name: Annotated[str, cappa.Arg(value_name="string name", help="more")]
-        short: Annotated[str, cappa.Arg(short=True, value_name="optional string")]
+        name: Annotated[str, cappa.Arg(value_name="string-name", help="more")]
+        short: Annotated[str, cappa.Arg(short=True, value_name="optional-string")]
 
     with pytest.raises(cappa.HelpExit) as e:
         parse(Args, "--help")


### PR DESCRIPTION
Fixes https://github.com/DanCardin/cappa/issues/53
Fixes https://github.com/DanCardin/cappa/issues/54