### PR TITLE
feat: Add option to apply custom output/error formatting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.11.0
+
+- Add option for explicit Output object, and add `error_format` option to allow
+  customizing output formatting.
+
 ## 0.10.2
 
 - Disallow explicit `required=False` in combination with the lack of a field

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cappa"
-version = "0.10.2"
+version = "0.11.0"
 description = "Declarative CLI argument parser."
 
 repository = "https://github.com/dancardin/cappa"

--- a/src/cappa/completion/base.py
+++ b/src/cappa/completion/base.py
@@ -7,11 +7,11 @@ from pathlib import Path
 from cappa.arg import Arg
 from cappa.command import Command
 from cappa.completion.shells import available_shells
-from cappa.output import Exit
+from cappa.output import Exit, Output
 from cappa.parser import Completion, FileCompletion, backend
 
 
-def execute(command: Command, prog: str, action: str, arg: Arg):
+def execute(command: Command, prog: str, action: str, arg: Arg, output: Output):
     shell_name = Path(os.environ.get("SHELL", "bash")).name
     shell = available_shells.get(shell_name)
 
@@ -26,6 +26,7 @@ def execute(command: Command, prog: str, action: str, arg: Arg):
     backend(
         command,
         command_args,
+        output=output,
         provide_completions=True,
     )
 

--- a/src/cappa/output.py
+++ b/src/cappa/output.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import io
 import sys
 import typing
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from rich.console import Console, NewLine
 from rich.markdown import Markdown
@@ -20,57 +20,131 @@ prompt_types = (Prompt, Confirm)
 Displayable: TypeAlias = typing.Union[str, Text, Table, NewLine, Markdown, Padding]
 
 
+theme: Theme = Theme(
+    {
+        "cappa.prog": "grey50",
+        "cappa.group": "dark_orange bold",
+        "cappa.arg": "cyan",
+        "cappa.arg.name": "dark_cyan",
+        "cappa.subcommand": "dark_cyan",
+        "cappa.help": "default",
+    }
+)
+
+
 @dataclass
 class Output:
-    output_console: Console
-    error_console: Console
-    theme: typing.ClassVar[Theme] = Theme(
-        {
-            "cappa.prog": "grey50",
-            "cappa.group": "dark_orange bold",
-            "cappa.arg": "cyan",
-            "cappa.arg.name": "dark_cyan",
-            "cappa.subcommand": "dark_cyan",
-            "cappa.help": "default",
-        }
+    """Output sink for CLI std out and error streams.
+
+    For simple customization (namely disabling color and overriding the theme),
+    `invoke` and `parse` accept `color` and `theme` arguments, which internally
+    configure the `output_console` and `error_console` fields.
+
+    For more involved customization, an Output object can be supplied into either `invoke`
+    or `parse` functions as well.
+
+    Note, all input arguments to Output are optional.
+
+    Arguments:
+        output_console: Output sink, defaults to printing to stdout.
+        error_console: Error sink, defaults to printing to stderr.
+        output_format: Format string through which output_console output will be
+            formatted. The following format string named format arguments can be used
+            in `output_format`: prog, code, message.
+        error_format: Format string through which output_console error will be
+            formatted. The following format string named format arguments can be used
+            in `output_format`: prog, code, message.
+
+    Examples:
+        >>> output = Output()
+        >>> output = Output(error_format="{prog}: error: {message}")
+    """
+
+    output_console: Console = field(
+        default_factory=lambda: Console(file=sys.stdout, theme=theme)
+    )
+    error_console: Console = field(
+        default_factory=lambda: Console(file=sys.stderr, theme=theme)
     )
 
-    @classmethod
-    def from_theme(cls, theme: Theme | None = None, color: bool = True):
-        no_color = None if color else True
-        theme = theme or cls.theme
-        output_console = Console(file=sys.stdout, theme=theme, no_color=no_color)
-        error_console = Console(file=sys.stderr, theme=theme, no_color=no_color)
-        return cls(output_console, error_console)
+    output_format: str = "{message}"
+    error_format: str = "[red]Error[/red]: {message}"
+
+    def color(self, value: bool = True):
+        """Override the default `color` setting (None), to an explicit True/False value."""
+        self.output_console.no_color = not value
+        self.error_console.no_color = not value
+        return self
+
+    def theme(self, t: Theme | None):
+        """Override the default Theme, or reset the theme back to default (with `None`)."""
+        self.output_console.push_theme(t or theme)
+        self.error_console.push_theme(t or theme)
 
     def exit(self, e: Exit):
+        """Print a `cappa.Exit` object to the appropriate console."""
         if e.code == 0:
             self.output(e)
         else:
             self.error(e)
 
-    def output(self, message: list[Displayable] | Displayable | Exit | None):
+    def output(
+        self, message: list[Displayable] | Displayable | Exit | str | None, **context
+    ):
+        """Output a message to the `output_console`.
+
+        Additional `**context` can be supplied into the `output_format` string template.
+        """
+        message = self._format_message(
+            self.output_console, message, self.output_format, **context
+        )
         self.write(self.output_console, message)
 
-    def error(self, message: list[Displayable] | Displayable | Exit | None):
+    def error(
+        self, message: list[Displayable] | Displayable | Exit | str | None, **context
+    ):
+        """Output a message to the `error_console`.
+
+        Additional `**context` can be supplied into the `error_format` string template.
+        """
+        message = self._format_message(
+            self.error_console, message, self.error_format, **context
+        )
         self.write(self.error_console, message)
 
-    def write(
-        self, console: Console, message: list[Displayable] | Displayable | Exit | None
-    ):
+    def _format_message(
+        self,
+        console: Console,
+        message: list[Displayable] | Displayable | Exit | str | None,
+        format: str,
+        **context,
+    ) -> Text | str | None:
+        code: int | str | None = None
+        prog = None
         if isinstance(message, Exit):
+            code = message.code
+            prog = message.prog
             message = message.message
 
         if message is None:
+            return None
+
+        text = rich_to_ansi(console, message)
+
+        inner_context = {
+            "code": code or 0,
+            "prog": prog,
+            "message": text,
+        }
+        final_context = {**inner_context, **context}
+
+        return Text.from_markup(format.format(**final_context))
+
+    def write(self, console: Console, message: Text | str | None):
+        if message is None:
             return
 
-        if isinstance(message, list):
-            messages = message
-        else:
-            messages = [message]
-
-        for m in messages:
-            console.print(m)
+        console.print(message, overflow="ignore")
 
 
 class TestPrompt(Prompt):
@@ -92,8 +166,10 @@ class Exit(SystemExit):
         message: list[Displayable] | Displayable | None = None,
         *,
         code: str | int | None = 0,
+        prog: str | None = None,
     ):
         self.message = message
+        self.prog = prog
         super().__init__(code)
 
 
@@ -103,6 +179,20 @@ class HelpExit(Exit):
         message: list[Displayable] | Displayable,
         *,
         code: str | int | None = 0,
+        prog: str | None = None,
     ):
-        super().__init__(code=code)
+        super().__init__(code=code, prog=prog)
         self.message = message
+
+
+def rich_to_ansi(
+    console: Console, message: list[Displayable] | Displayable | str
+) -> str:
+    with console.capture() as capture:
+        if isinstance(message, list):
+            for m in message:
+                console.print(m)
+        else:
+            console.print(message)
+
+    return capture.get().strip()

--- a/src/cappa/subcommand.py
+++ b/src/cappa/subcommand.py
@@ -82,10 +82,10 @@ class Subcommand:
             group=group,
         )
 
-    def map_result(self, parsed_args):
+    def map_result(self, prog: str, parsed_args):
         option_name = parsed_args.pop("__name__")
         option = self.options[option_name]
-        return option.map_result(option, parsed_args)
+        return option.map_result(option, prog, parsed_args)
 
     def names(self) -> list[str]:
         return list(self.options.keys())

--- a/src/cappa/testing.py
+++ b/src/cappa/testing.py
@@ -19,6 +19,7 @@ class RunnerArgs(typing.TypedDict, total=False):
     obj: type
     deps: typing.Sequence[typing.Callable]
     backend: typing.Callable | None
+    output: cappa.Output | None
     color: bool
     version: str | cappa.Arg
     help: bool | cappa.Arg
@@ -70,6 +71,7 @@ class CommandRunner:
     obj: type | None = None
     deps: typing.Sequence[typing.Callable] | None = None
     backend: typing.Callable | None = None
+    output: cappa.Output | None = None
     color: bool = True
     version: str | cappa.Arg | None = None
     help: bool | cappa.Arg = True
@@ -81,6 +83,7 @@ class CommandRunner:
             "argv": self.base_args + list(args),
             "obj": kwargs.get("obj") or self.obj,
             "backend": kwargs.get("backend") or self.backend,
+            "output": kwargs.get("output") or self.output,
             "color": kwargs.get("color") or self.color,
             "version": kwargs.get("version") or self.version,
             "help": kwargs.get("help") or self.help,

--- a/tests/help/test_name.py
+++ b/tests/help/test_name.py
@@ -38,6 +38,5 @@ def test_argument_name(capsys):
             [--completion COMPLETION]  Use `--completion generate` to print
                                        shell-specific completion source. Valid options:
                                        generate, complete.
-
         """
     )

--- a/tests/invoke/test_output.py
+++ b/tests/invoke/test_output.py
@@ -20,4 +20,4 @@ def test_outputs_output(backend, capsys):
 
     outerr = capsys.readouterr()
     assert outerr.out == "woah!\n"
-    assert outerr.err == "woops!\n"
+    assert outerr.err == "Error: woops!\n"

--- a/tests/parser/test_custom_callable_action.py
+++ b/tests/parser/test_custom_callable_action.py
@@ -83,3 +83,22 @@ def test_subcommand_name(backend):
 
     args = parse(Args, "sub-b", "sub-b-sub", "-v", "one", backend=backend)
     assert args.cmd.cmd.value == "sub-b-sub"
+
+
+################################
+def custom_out(out: cappa.Output):
+    out.output("woah")
+    return 1
+
+
+@backends
+def test_custom_action_output_dep(backend, capsys):
+    @dataclass
+    class Args:
+        value: Annotated[int, cappa.Arg(action=custom_out, short=True)]
+
+    args = parse(Args, "-v", "one", backend=backend)
+    assert args.value == 1
+
+    out = capsys.readouterr().out
+    assert out == "woah\n"

--- a/tests/parser/test_missing_num_args.py
+++ b/tests/parser/test_missing_num_args.py
@@ -24,6 +24,6 @@ def test_invalid_choice_help(backend):
 
     message = str(e.value.message)
     if backend == argparse.backend:
-        assert "the following arguments are required: arg" in message
+        assert "The following arguments are required: arg" in message
     else:
-        assert message == "Argument requires 2 values, only found 1 ('arg' so far)."
+        assert message == "Argument requires 2 values, only found 1 ('arg' so far)"

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,9 +1,13 @@
+import textwrap
 from dataclasses import dataclass
 
 import cappa
 import pytest
+from rich.table import Table
+from rich.text import Text
+from typing_extensions import Annotated
 
-from tests.utils import backends
+from tests.utils import backends, parse
 
 
 @backends
@@ -41,7 +45,7 @@ def test_invoke_exit_success_without_message(capsys, backend):
 
 
 @backends
-def test_invoke_exit_errror(capsys, backend):
+def test_invoke_exit_error(capsys, backend):
     def fn():
         raise cappa.Exit("With message", code=1)
 
@@ -55,4 +59,72 @@ def test_invoke_exit_errror(capsys, backend):
 
     assert e.value.code == 1
     out = capsys.readouterr().err
-    assert out == "With message\n"
+    assert out == "Error: With message\n"
+
+
+@backends
+def test_error_output_rich_text(capsys, backend):
+    def fn():
+        raise cappa.Exit(Text("With message"), code=1)
+
+    @cappa.command(invoke=fn)
+    @dataclass
+    class Example:
+        ...
+
+    with pytest.raises(cappa.Exit) as e:
+        cappa.invoke(Example, argv=[], backend=backend)
+
+    assert e.value.code == 1
+    out = capsys.readouterr().err
+    assert out == "Error: With message\n"
+
+
+@backends
+def test_explicit_output_prefix(capsys, backend):
+    @cappa.command(name="asdf")
+    @dataclass
+    class Example:
+        ...
+
+    output = cappa.Output(error_format="{prog}: error({code}): {message}.")
+    with pytest.raises(cappa.Exit) as e:
+        parse(Example, "--fooooo", backend=backend, output=output)
+
+    assert e.value.code == 2
+    out = capsys.readouterr().err
+    assert out == "asdf: error(2): Unrecognized arguments: --fooooo.\n"
+
+
+def _debug(output: cappa.Output):
+    table = Table(style="blue")
+    table.add_row("one", "two")
+    output.error(table)
+    raise cappa.Exit(code=0)
+
+
+@backends
+def test_output_formatting_complex_rich_object(capsys, backend):
+    @dataclass
+    class Example:
+        debug_info: Annotated[
+            bool,
+            cappa.Arg(long=True, action=_debug, num_args=0),
+        ] = False
+
+    output = cappa.Output(error_format="[red]Error[/red]:\n{message}!")
+    with pytest.raises(cappa.Exit) as e:
+        parse(Example, "--debug-info", output=output, backend=backend)
+
+    assert e.value.code == 0
+    out = capsys.readouterr().err
+    assert out == textwrap.dedent(
+        """\
+        Error:
+        ┏━━━━━┳━━━━━┓
+        ┃     ┃     ┃
+        ┡━━━━━╇━━━━━┩
+        │ one │ two │
+        └─────┴─────┘!
+        """
+    )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,8 +11,8 @@ backends = pytest.mark.parametrize("backend", [None, argparse.backend])
 runner = CommandRunner(base_args=[])
 
 
-def parse(cls, *args, backend=None):
-    return runner.parse(*args, obj=cls, backend=backend)
+def parse(cls, *args, **kwargs):
+    return runner.parse(*args, obj=cls, **kwargs)
 
 
 def invoke(cls, *args, **kwargs):


### PR DESCRIPTION
Fixes https://github.com/DanCardin/cappa/issues/43

Given
```python
def _debug(output: cappa.Output):
    table = Table(style="blue")
    table.add_row("one", "two")
    output.error(table)
    raise cappa.Exit(code=0)


@dataclass
class Example:
    foo: str
    debug_info: Annotated[
        bool,
        cappa.Arg(long=True, action=_debug, num_args=0),
        Doc("Print debug information."),
    ] = False


output = cappa.Output(error_format="[red]Error[/red]:\n{message}!")
args: Example = cappa.parse(Example, output=output)
```

<img width="301" alt="Screenshot 2023-10-25 at 6 43 46 AM" src="https://github.com/DanCardin/cappa/assets/701548/76cbc026-d686-4fe3-85c8-d9923f04629a">
