### PR TITLE
fix: Disallow certain combinations of apparently incompatible annotations.

### DIFF
--- a/docs/source/annotation.md
+++ b/docs/source/annotation.md
@@ -1,14 +1,18 @@
 # Annotations
 
-Annotations are use to control the output type of each argument, and infer type
-cast/parsing logic on behalf of the programmer.
+Annotations perform two functions:
+
+- Inferring specific `Arg`-level options, depending on the specific annotation,
+  most of which control parsing behavior for that argument.
+
+- Mapping the raw parsed arguments into the specified output types.
 
 In any case where the "supported" set of behaviors given by the inference system
 does not produce the obvious result, feel free to submit a bug report. The
 intent is that it should feel natural for all supportable cases. For any cases
 where it does not make sense to build in specific behavior for a type (for
 example, third-party library types), you can instead use the correct annotation
-while providing the `parse` [Argument](./arg.md) argument, or other options.
+while providing the `parse`, or other [arguments](./arg.md).
 
 ```{note}
 Use of `Annotated` throughout the examples and docs is fairly pervasive. When using
@@ -18,28 +22,171 @@ Instead, you can install [typing_extensions](https://pypi.org/project/typing_ext
 which backports typing objects to earlier versions of python.
 ```
 
-## Basic Data Types
-
-Any "basic" data type (like `int`, `float`, `str`) are supported and coerced to
-directly.
-
-This also applies even to "complex" ones who's constructor accepts a string and
-returns the type (such as `pathlib.Path`, or `decimal.Decimal`)
-
-## Union (and Optional)
-
 ```{note}
-`Optional` is just shorthand for `Union[T, None]`, so it falls under `Union` handling.
-
-The **only** additional behavior is that unioning with `None` automatically makes the
-flag optional (i.e. `required=False`).
+Similarly, use of `|` for `Union`s is universally preferred in the docs. When using
+versions of python below 3.10, you may need to use `from __future__ import annotations`
+at the top of your file in order for the annotations to be ignored by the python runtime.
 ```
 
-Unions are handled by recursively processing the set of unioned types using the
-same logic. The primary important point here, is that the order of the set of
-unioned types **can** matter, but generally shouldnt.
+## Positional vs Option
 
-The unioned types are sorted (and thus handled) in descending order from:
+Below, any reference to "positional" implies, a field which does not set
+`short=...` or `long=...`. This includes any fields with no explicit `Arg`
+instance at all.
+
+- `foo: str`
+- `foo: Annotated[str, Arg()]`
+
+Whereas an "option" is a field which **does** set `short=...` or `long=...`.
+
+- `foo: Annotated[str, Arg(short=True)]`
+- `foo: Annotated[str, Arg(long=True)]`
+- `foo: Annotated[str, Arg(short="-f", long=True)]`
+
+This is an important distinction to note, because the inference system makes
+difference decisions, depending on whether a given field is positional or not.
+
+## `Arg` Inference
+
+Note that in all cases below, any individual inferred value can be overridden in
+any case where the default inference is not what you're looking for!
+
+### Bool
+
+In most other cases, an un-annotated field like `foo: str` is assumed to be a
+positional argument.
+
+By contrast a `foo: bool` is assumed to be an optional flag. This is because
+bools corresponding to flags represent the much more common case.
+
+By default a `foo: bool` implies
+`foo: Annotated[bool, Arg(long=True, num_args=0, action=ArgAction.store_true, required=False)]`.
+
+- If you also want to enable a "short" version of the flag, you can set
+  `Arg(short=True)`.
+
+- If you include a `--no-<name>` long name variant like
+  `Arg(long=['--foo', '--no-foo'])`, the `--no-foo` variant will be inferred as
+  `ArgAction.store_false`.
+
+- If a vanilla bool annotation (without an inverted variant) is combined with a
+  default value of `True`, then the action is inverted to
+  `ArgAction.store_false`.
+
+  This is because `foo: bool = True` could never result in a `False` value, if
+  supplying `--foo` at the command line also stored `True`.
+
+See [Arg.short](cappa.Arg.short) and [Arg.long](cappa.Arg.long) for more details
+on customization of the specific flag names.
+
+```{note}
+If (for whatever reason) you require a positional argument interpreted as a bool,
+you can explicitly set `Arg(long=None, action=ArgAction.set, num_args=1)`
+```
+
+### Sequence Types
+
+Annotations like `list[...]`, `set[...]`, `tuple[...]`, etc are what we call
+"sequence types".
+
+- In the case of a positional argument, a sequence type annotation implies
+  `Arg(..., num_args=length_bound)`.
+
+  For "bounded" length sequences (i.e. tuples like `tuple[int]`,
+  `tuple[int, int]`, `tuple[int, int, int]`, etc), `length_bound` corresponds to
+  the indicated length of the sequence.
+
+  For "unbounded" length sequences (i.e. list, set, and unbounded tuples:
+  `tuple[int, ...]`), `length_bound=-1`, i.e. the argument will consume an
+  unbounded number of positional arguments (`prog foo bar baz ...`).
+
+  ```python
+  @dataclass
+  class Prog:
+      foo: list[str]
+
+  prog = cappa.parse(Prog, argv=['foo', 'bar', 'baz'])
+  assert prog == Prog(foo=['foo', 'bar', 'baz'])
+  ```
+
+- In the case of option arguments, a sequence type annotation implies
+  `Arg(..., action=ArgAction.append)`. That is, it allows multiple uses of the
+  option to accumulate the values into a sequence.
+
+  ```python
+  @dataclass
+  class Prog:
+      foo: Annotated[list[str], Arg(short=True)]
+
+  prog = cappa.parse(Prog, argv=['-f', 'foo', '-f', 'bar', '-f', 'baz'])
+  assert prog == Prog(foo=['foo', 'bar', 'baz'])
+  ```
+
+See [Argument](./arg.md) for more details on the difference between
+`ArgAction.append` and `num_args=-1`.
+
+### `| None` or `Optional[...]`
+
+Either form of `Optional`-type annotation implies
+`Arg(required=False, default=None)`.
+
+### Literals and Enums
+
+Any form of explicit "choice", like `Literal["one", "two"]`,
+`Literal["one"] | Literal["two"]`, `Enum` implies `Arg(choices=[...])`.
+
+In case of literals, it is obviously the list of all unioned literals. In case
+of `Enum` subclasses, all variants are given as the set of choices.
+
+`choices` represents a parser-level evaluation of the CLI input value versus the
+available choices, resulting in a parse error in the event the value does not
+match.
+
+### Subcommands
+
+Unions among subcommand options `Subcommands[One | Two | Three]` are how
+subcommand options are expressed. See [Command](./command.md) docs for more
+details.
+
+The order of the unioned subcommand options does not have any effect because
+each subcommand has a unambiguous name.
+
+## Mapping Inference
+
+Mapping inference is a sort of subset of `Arg`-settings inference, in that it
+effectively uses the annotated type to set `Arg(parse=...)` in a way that maps
+the raw values coming out of a sucessful CLI parse into the annotated types.
+
+As such you can again, opt out of the "Mapping inference" entirely, by supplying
+your own `parse` function.
+
+```{note}
+Mapping inference is built up out of component functions defined in `cappa.annotation`,
+such as `parse_list`, which know how to translate `list[int]` and a source list of raw
+parser strings into a list of ints.
+
+These functions can/could be utilized in your own custom `parse` functions.
+```
+
+### Basic Scalar Types
+
+Any "basic" data type (like `int`, `float`, `str`) are supported and coerced to
+directly, by calling their constructor.
+
+This also applies even to "complex" ones who's constructor accepts a string and
+returns the type (such as `pathlib.Path`, or `decimal.Decimal`).
+
+Note this also applies to `Enum`s, who's raw values by map-time should be
+guaranteed to be compatible with the Enum's variants.
+
+### Union (and Optional)
+
+Unions are handled by recursively processing the set of unioned inner types
+using whatever logic applies to that type. The primary important point here, is
+that the order of the set of unioned types **can** matter, but generally
+shouldnt.
+
+The unioned types are sorted and processed in descending order from:
 
 - "other" types/None
 - float
@@ -47,89 +194,18 @@ The unioned types are sorted (and thus handled) in descending order from:
 - bool/str
 
 This specific order order is given to prioritize types which are less likely to
-succeed parsing when given incorrect input. Whereas, for example, `bool` or
-`str` will always "succeed" (in that given any input they will produce an
-output).
+succeed parsing when given incorrect input.
+
+`bool` and `str` are notable in that will always "succeed" (in that given any
+input they will produce an output) and not fail. As such it **may** not make
+much sense to union those types together without an explicit `parse`.
 
 Therefore, when unioning "other"-type types, it **may** be important to consider
 the order of the unioned types, if parsing for one or the other type would
 "succeed" incorrectly. In such cases, `parse` may be appropriate.
 
-```{note}
-Unions are how selections among subcommand options are expressed. See
-[Command](./command.md) docs for more details.
+### List/Tuple/Set
 
-The order of the unioned subcommand options removes order ambiguity, because
-each subcommand has a unambiguous name.
-```
-
-## List
-
-A `list[...]` annotation will:
-
-- Cause the argument to accumulate an unbounded number of values
-- Coerce the resultant value into a list, as well as coerce the inner type, if
-  supplied.
-
-For a specific number of values, you should instead use a tuple.
-
-In the case of a positional argument, this implies `Arg(..., num_args=-1)`. That
-is, that the argument will consume an unbounded number of positional arguments.
-
-In the case of an "option" (e.x. `Arg(short='-t')`), this implies
-`Arg(..., action=ArgAction.append)`. That is, unbounded instances of `-t` are
-allowed, and accumulate their individual values into a list.
-
-For unbounded consumption on a single option, see [num_args](./arg.md#num-args).
-
-## Tuple
-
-Tuples change the number of args parsed by the option to the number items in the
-tuple.
-
-In the event something like `tuple[T, ...]` is encountered, type checkers
-interpret this to mean unbounded size tuple of type T. Which here means
-identical handling as for lists, but ultimately cast to tuple.
-
-Tuples coerce to whatever the inner type(s) is/are.
-
-## Bool
-
-Because there's no real alternative option for bools, they are automatically
-assumed to be flags. `long=True` is assumed, although both `long` and `short`
-can be explicitly set, if you dont want the default name.
-
-- `bool` changes the "action" to "store_true", which results in the argument
-  accepting no additional "value" field.
-
-- If the `long` options for the flag include a `--no-*` version (such as
-  `Arg(long="--foo/--no-foo")`, i.e. `Arg(long=["--foo", "--no-foo"])`), then
-  the "no" variant will invert the given "action" for that variant of the flag.
-
-  By default that translates to the obvious behavior of `--foo` storing `True`,
-  and `--no-foo` storing `False`.
-
-- If the flag does not have an inverted variant like above, and the default
-  value for the field is `True`, then the arg will be inferred as `store_false`.
-
-  Without this behavior, the flag would have no way to store anything but `True`
-
-## Literal
-
-Literal unions, like `Literal["foo"] | Literal["bar"] | Literal["bar"]`,
-translate into "choices" which ensure the value is one of the literal values.
-
-This **could** be used to disambiguate a more complex type combination like
-`tuple[Literal['int'], int] | tuple[Literal['float'], float]`, where it might
-otherwise not have been possible to easily parse into the correct type.
-
-## Enum
-
-Enums are handled similarly to literals, except that you end up with the enum
-variant instance as the returned type, rather than the literal input value.
-
-## Dataclass (and alike)
-
-The parsed value is `**splatted` into the annotated class. Note, this is only
-really relevant for subcommands, because it's the only real way to get
-\*\*splattable input values.
+`list[...]`, `tuple[...]`, `set[...]` all will coerce the parsed sequences of
+values into their corresponding type. The inner type will be mapped for each
+item in the sequence.

--- a/docs/source/arg.md
+++ b/docs/source/arg.md
@@ -125,15 +125,53 @@ class Example:
    :noindex:
 ```
 
+```{warning}
+`ArgAction.append` and `num_args=-1` can be potentially confused, in that they can both
+produce list/sequence types as outputs. They can be used in conjunction or separately,
+but they are not the same!
+
+Given some example option `--foo`:
+
+`ArgAction` generally, affects the way the parser maps input CLI values to a given field
+overall. As such `ArgAction.append` causes the field-level value to be a sequence, and
+for multiple instances of `--foo` to accumulate into a list. e.x. `--foo 1 --foo 2` -> `[1, 2]`.
+
+`num_args` instead, affects the number of values that a single instance of `--foo` will
+consume before stopping. e.x. `--foo 1 2` -> `[1, 2]`.
+
+From an input perspective, the above examples show how they present differently at the CLI
+interface, requiring different inputs to successfully parse. From an output perspective, the
+table below shows how their parsed output will end up looking when mapped to real values.
+
+| action | num_args | result |
+| ------ | -------- | ------ |
+| set    | 1        | 1      |
+| set    | -1       | [1]    |
+| append | 1        | [1]    |
+| append | -1       | [[1]]  |
+```
+
 ## Num Args
 
-Generally `num_args` will be inferred by [annotations](./annotation.md), and
-(hopefully) do the obvious thing. It can be manually set, if the inferred value
-is not the expected behavior.
+`num_args` controls the number of arguments that the parser will consume in
+order to fullfill a specific field. `num_args=1` is the default behavior,
+meaning only one argument/value will be consumed for that field. This yields a
+scalar-type value.
 
-For example, in order to support an option
-(`Annotated[list[str], Arg(long='--foo')]`) which consumes an unbounded series
-of arguments (`--foo 1 2 3 4 5 ...`), you would need to specify `num_args=-1`.
+`num_args=3` would therefore mean that exactly 3 values would be required,
+resulting in a sequence-type output, rather than a scalar one.
+
+`num_args=-1` can be used to indicate that 0 or more (i.e. unbounded number of)
+arguments will be consumed, similarly resulting in a sequence-type output (even
+in the zero case).
+
+```{note}
+Generally `num_args` will be automatically inferred by your type annotation. For example,
+`tuple[int, int, int]` implies `num_args=3`.
+
+However, an explicitly provided value is always preferred to the inferred value.
+See [annotations](./annotation.md) for more details.
+```
 
 ## Default
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cappa"
-version = "0.11.5"
+version = "0.11.6"
 description = "Declarative CLI argument parser."
 
 repository = "https://github.com/dancardin/cappa"

--- a/src/cappa/annotation.py
+++ b/src/cappa/annotation.py
@@ -4,7 +4,7 @@ import enum
 import types
 import typing
 
-from typing_inspect import is_literal_type
+from typing_inspect import get_origin, is_literal_type
 
 from cappa.typing import T, backend_type, is_none_type, is_subclass, is_union_type
 
@@ -182,3 +182,7 @@ def detect_choices(origin: type, type_args: tuple[type, ...]) -> list[str] | Non
         return [str(t) for t in type_args]
 
     return None
+
+
+def is_sequence_type(typ):
+    return is_subclass(get_origin(typ) or typ, (typing.List, typing.Tuple, typing.Set))

--- a/tests/arg/test_invalid_annotation_combination.py
+++ b/tests/arg/test_invalid_annotation_combination.py
@@ -1,0 +1,89 @@
+from dataclasses import dataclass
+from typing import List, Union
+
+import cappa
+import pytest
+from typing_extensions import Annotated
+
+from tests.utils import backends, parse
+
+
+@backends
+def test_sequence_unioned_with_scalar(backend):
+    @dataclass
+    class Args:
+        foo: Union[List[str], str]
+
+    with pytest.raises(ValueError) as e:
+        parse(Args, "--help", backend=backend)
+
+    assert str(e.value) == (
+        "On field 'foo', apparent mismatch of annotated type with `Arg` options. "
+        'Unioning "sequence" types with non-sequence types is not currently supported, '
+        "unless using `Arg(parse=...)` or `Arg(action=<callable>)`. "
+        "See [documentation](https://cappa.readthedocs.io/en/latest/annotation.html) for more details."
+    )
+
+
+@backends
+def test_sequence_with_scalar_action(backend):
+    @dataclass
+    class Args:
+        foo: Annotated[List[str], cappa.Arg(action=cappa.ArgAction.set)]
+
+    with pytest.raises(ValueError) as e:
+        parse(Args, "--help", backend=backend)
+
+    assert str(e.value) == (
+        "On field 'foo', apparent mismatch of annotated type with `Arg` options. "
+        "'typing.List[str]' type produces a sequence, whereas `num_args=1`/`action=ArgAction.set` do not. "
+        "See [documentation](https://cappa.readthedocs.io/en/latest/annotation.html) for more details."
+    )
+
+
+@backends
+def test_sequence_with_scalar_num_args(backend):
+    @dataclass
+    class Args:
+        foo: Annotated[List[str], cappa.Arg(num_args=1, short=True)]
+
+    with pytest.raises(ValueError) as e:
+        parse(Args, "--help", backend=backend)
+
+    assert str(e.value) == (
+        "On field 'foo', apparent mismatch of annotated type with `Arg` options. "
+        "'typing.List[str]' type produces a sequence, whereas `num_args=1`/`action=None` do not. "
+        "See [documentation](https://cappa.readthedocs.io/en/latest/annotation.html) for more details."
+    )
+
+
+@backends
+def test_scalar_with_sequence_action(backend):
+    @dataclass
+    class Args:
+        foo: Annotated[str, cappa.Arg(action=cappa.ArgAction.append)]
+
+    with pytest.raises(ValueError) as e:
+        parse(Args, "--help", backend=backend)
+
+    assert str(e.value) == (
+        "On field 'foo', apparent mismatch of annotated type with `Arg` options. "
+        "'str' type produces a scalar, whereas `num_args=None`/`action=ArgAction.append` do not. "
+        "See [documentation](https://cappa.readthedocs.io/en/latest/annotation.html) for more details."
+    )
+
+
+@backends
+def test_scalar_with_sequence_num_args(backend):
+    @dataclass
+    class Args:
+        foo: Annotated[str, cappa.Arg(num_args=5)]
+
+    with pytest.raises(ValueError) as e:
+        parse(Args, "--help", backend=backend)
+
+    assert str(e.value) == (
+        "On field 'foo', apparent mismatch of annotated type with `Arg` options. "
+        "'str' type produces a scalar, whereas `num_args=5`/`action=None` do not. "
+        "See [documentation](https://cappa.readthedocs.io/en/latest/annotation.html) for more details."
+    )

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,10 +1,7 @@
 def successful_test_run(pytester, *, count=None, skipped_count=0):
     pytester.copy_example()
     result = pytester.runpytest_inprocess(
-        "-vv",
-        "--log-cli-level=WARNING",
-        "--log-level=WARNING",
-        "conftest.py",
+        "-vv", "--log-cli-level=WARNING", "--log-level=WARNING", "conftest.py"
     )
     result.assert_outcomes(passed=count, skipped=skipped_count, failed=0)
 


### PR DESCRIPTION
Addresses suggestions extracted from https://github.com/DanCardin/cappa/issues/74, by disallowing combinations that would otherwise produce confusing results or runtime errors during mapping