### PR TITLE
fix: Special case None type handling in combination with explicit `parse` functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.12.1
+
+- When used in combination with `parse=...`, handle the "optional" part of
+  `T | None` **before** `parse`.
+
 ## 0.12.0
 
 - Add `invoke_async` to support async invoke functions and dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cappa"
-version = "0.12.0"
+version = "0.12.1"
 description = "Declarative CLI argument parser."
 
 repository = "https://github.com/dancardin/cappa"

--- a/src/cappa/annotation.py
+++ b/src/cappa/annotation.py
@@ -23,10 +23,11 @@ __all__ = [
 type_priority: typing.Final = types.MappingProxyType(
     {
         None: 0,
-        float: 1,
-        int: 2,
-        bool: 3,
-        str: 4,
+        ...: 1,
+        float: 2,
+        int: 3,
+        bool: 4,
+        str: 5,
     }
 )
 
@@ -133,7 +134,7 @@ def parse_union(*type_args: type) -> typing.Callable[[typing.Any], typing.Any]:
     """Create a value parser for a Union with type-args of given `type_args`."""
 
     def type_priority_key(type_) -> int:
-        return type_priority.get(type_, 0)
+        return type_priority.get(type_, 1)
 
     mappers: list[typing.Callable] = [
         parse_value(t) for t in sorted(type_args, key=type_priority_key)
@@ -151,6 +152,18 @@ def parse_union(*type_args: type) -> typing.Callable[[typing.Any], typing.Any]:
         )
 
     return union_mapper
+
+
+def parse_optional(
+    parser: typing.Callable[[typing.Any | None], T]
+) -> typing.Callable[[typing.Any | None], T | None]:
+    def optional_mapper(value) -> T | None:
+        if value is None:
+            return None
+
+        return parser(value)
+
+    return optional_mapper
 
 
 def parse_none():

--- a/src/cappa/arg.py
+++ b/src/cappa/arg.py
@@ -8,7 +8,12 @@ from collections.abc import Callable
 
 from typing_inspect import is_optional_type
 
-from cappa.annotation import detect_choices, is_sequence_type, parse_value
+from cappa.annotation import (
+    detect_choices,
+    is_sequence_type,
+    parse_optional,
+    parse_value,
+)
 from cappa.class_inspect import Field, extract_dataclass_metadata
 from cappa.completion.completers import complete_choices
 from cappa.completion.types import Completion
@@ -425,6 +430,8 @@ def infer_num_args(
 
 def infer_parse(arg: Arg, annotation: type) -> Callable:
     if arg.parse:
+        if is_optional_type(annotation):
+            return parse_optional(arg.parse)
         return arg.parse
 
     return parse_value(annotation)


### PR DESCRIPTION
Without this, some field `foo: Annotated[int | None, Arg(parse=int)] = None`, which would **seem** like it should work (even if there's no need to use an explicit parse here), will fail because it unconditionally runs the parse.

Now, it will detect optional source types, and apply an optional aware wrapper around the given input `parse`.

If this behavior breaks something, i'd rather we handle that directly at time that it's identified. As-is, its not obvious why you'd annotate it as potentially `None`, if it shouldn't be allowed to be None.