### PR TITLE
feat: Implement yield dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.13.0
+
+- Support `yield` in invoke dependencies to support context-manager-like
+  dependencies (for example those which require cleanup).
+
 ## 0.12.1
 
 - When used in combination with `parse=...`, handle the "optional" part of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cappa"
-version = "0.12.1"
+version = "0.13.0"
 description = "Declarative CLI argument parser."
 
 repository = "https://github.com/dancardin/cappa"

--- a/src/cappa/base.py
+++ b/src/cappa/base.py
@@ -133,8 +133,11 @@ def invoke(
         command, parsed_command, instance, output=concrete_output, deps=deps
     )
     for dep in global_deps:
-        dep.get(concrete_output)
-    return resolved.get(concrete_output)
+        with dep.get(concrete_output):
+            pass
+
+    with resolved.get(concrete_output) as value:
+        return value
 
 
 async def invoke_async(
@@ -194,8 +197,11 @@ async def invoke_async(
         command, parsed_command, instance, output=concrete_output, deps=deps
     )
     for dep in global_deps:
-        await dep.get_async(concrete_output)
-    return await resolved.get_async(concrete_output)
+        async with dep.get_async(concrete_output):
+            pass
+
+    async with resolved.get_async(concrete_output) as value:
+        return value
 
 
 def parse_command(

--- a/tests/invoke/test_async_generator_dependency.py
+++ b/tests/invoke/test_async_generator_dependency.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import asyncio
+import csv
+import io
+import logging
+from dataclasses import dataclass
+
+import cappa
+from typing_extensions import Annotated
+
+from tests.utils import backends, invoke_async
+
+log = logging.getLogger("test")
+
+
+async def binary_io():
+    print("binary before")
+    with io.BytesIO() as buffer:
+        yield buffer
+    print("binary after")
+
+
+async def text_io(binary_io: Annotated[io.BytesIO, cappa.Dep(binary_io)]):
+    print("text before")
+    text_buffer = io.TextIOWrapper(binary_io)
+    yield text_buffer
+    print("text after")
+
+
+async def csv_file(text_io: Annotated[io.TextIOWrapper, cappa.Dep(text_io)]):
+    print("csv before")
+    writer = csv.DictWriter(text_io, ["foo", "bar"])
+    writer.writeheader()
+    writer.writerow({"foo": 1, "bar": "woah"})
+    text_io.detach()
+    yield writer
+    print("csv after")
+
+
+def command(
+    _: Annotated[dict, cappa.Dep(csv_file)],
+    binary_io: Annotated[io.BytesIO, cappa.Dep(binary_io)],
+):
+    assert not binary_io.closed
+    return binary_io, binary_io.getvalue()
+
+
+@cappa.command(invoke=command)
+@dataclass
+class Command:
+    ...
+
+
+@backends
+def test_invoke_top_level_command(backend, capsys):
+    buffer, result = asyncio.run(invoke_async(Command, backend=backend))
+
+    assert buffer.closed is True
+    assert result == b"foo,bar\r\n1,woah\r\n"
+
+    out = capsys.readouterr().out
+    assert out == (
+        "binary before\n"
+        "text before\n"
+        "csv before\n"
+        "csv after\n"
+        "text after\n"
+        "binary after\n"
+    )

--- a/tests/invoke/test_generator_dependency.py
+++ b/tests/invoke/test_generator_dependency.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import csv
+import io
+import logging
+from dataclasses import dataclass
+
+import cappa
+from typing_extensions import Annotated
+
+from tests.utils import backends, invoke
+
+log = logging.getLogger("test")
+
+
+def binary_io():
+    print("binary before")
+    with io.BytesIO() as buffer:
+        yield buffer
+    print("binary after")
+
+
+def text_io(binary_io: Annotated[io.BytesIO, cappa.Dep(binary_io)]):
+    print("text before")
+    text_buffer = io.TextIOWrapper(binary_io)
+    yield text_buffer
+    print("text after")
+
+
+def csv_file(text_io: Annotated[io.TextIOWrapper, cappa.Dep(text_io)]):
+    print("csv before")
+    writer = csv.DictWriter(text_io, ["foo", "bar"])
+    writer.writeheader()
+    writer.writerow({"foo": 1, "bar": "woah"})
+    text_io.detach()
+    yield writer
+    print("csv after")
+
+
+def command(
+    _: Annotated[dict, cappa.Dep(csv_file)],
+    binary_io: Annotated[io.BytesIO, cappa.Dep(binary_io)],
+):
+    assert not binary_io.closed
+    return binary_io, binary_io.getvalue()
+
+
+@cappa.command(invoke=command)
+@dataclass
+class Command:
+    ...
+
+
+@backends
+def test_invoke_top_level_command(backend, capsys):
+    buffer, result = invoke(Command, backend=backend)
+
+    assert buffer.closed is True
+    assert result == b"foo,bar\r\n1,woah\r\n"
+
+    out = capsys.readouterr().out
+    assert out == (
+        "binary before\n"
+        "text before\n"
+        "csv before\n"
+        "csv after\n"
+        "text after\n"
+        "binary after\n"
+    )


### PR DESCRIPTION
The implementation for https://github.com/DanCardin/cappa/issues/76 lended itself to also enabling "yield" dependencies. I.e. dependencies which act as context managers through the use of `yield`.

Basically a feature I didn't realize I wanted until it came up that it'd be useful, and which was directly enabled by supporting asyncio in the invoke system two days earlier 😆 