### PR TITLE
fix: Prefer the field default (if set), if an `Env` is used, but no d…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.13.1
+
+- Prefer the field default (if set), if an `Env` is used, but no default is
+  supplied.
+
 ## 0.13.0
 
 - Support `yield` in invoke dependencies to support context-manager-like

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cappa"
-version = "0.13.0"
+version = "0.13.1"
 description = "Declarative CLI argument parser."
 
 repository = "https://github.com/dancardin/cappa"

--- a/tests/arg/test_env.py
+++ b/tests/arg/test_env.py
@@ -48,3 +48,13 @@ def test_mapping_is_applied(backend):
 
     test = parse(ArgTest, backend=backend)
     assert test.default is True
+
+
+@backends
+def test_class_default_gets_applied_to_env_default(backend):
+    @dataclass
+    class ArgTest:
+        default: Annotated[str, cappa.Arg(default=cappa.Env("ASDF"))] = "wat"
+
+    test = parse(ArgTest, backend=backend)
+    assert test.default == "wat"


### PR DESCRIPTION
…efault is supplied.