### PR TITLE
 fix: Default bool fields to False when omitted. 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cappa"
-version = "0.14.1"
+version = "0.14.2"
 description = "Declarative CLI argument parser."
 
 repository = "https://github.com/dancardin/cappa"

--- a/src/cappa/arg.py
+++ b/src/cappa/arg.py
@@ -301,6 +301,9 @@ def infer_default(arg: Arg, field: Field, annotation: type) -> typing.Any:
     if is_optional_type(annotation):
         return None
 
+    if is_subclass(annotation, bool):
+        return False
+
     return missing
 
 

--- a/src/cappa/typing.py
+++ b/src/cappa/typing.py
@@ -103,12 +103,14 @@ def is_subclass(typ, superclass):
 
 def get_type_hints(obj, include_extras=False):
     result = typing_extensions.get_type_hints(obj, include_extras=include_extras)
-    return fix_annotated_optional_type_hints(result)
+    if sys.version_info < (3, 11):  # pragma: no cover
+        return fix_annotated_optional_type_hints(result)
+    return result
 
 
 def fix_annotated_optional_type_hints(
     hints: dict[str, typing.Any]
-) -> dict[str, typing.Any]:
+) -> dict[str, typing.Any]:  # pragma: no cover
     """Normalize `Annotated` interacting with `get_type_hints` in versions <3.11.
 
     https://github.com/python/cpython/issues/90353.

--- a/tests/arg/test_bool.py
+++ b/tests/arg/test_bool.py
@@ -10,6 +10,19 @@ from tests.utils import backends, parse
 
 
 @backends
+def test_missing_default(backend):
+    @dataclass
+    class ArgTest:
+        default: bool
+
+    test = parse(ArgTest, backend=backend)
+    assert test.default is False
+
+    test = parse(ArgTest, "--default", backend=backend)
+    assert test.default is True
+
+
+@backends
 def test_default(backend):
     @dataclass
     class ArgTest:


### PR DESCRIPTION
This causes `foo: bool` to automatically infer as `default=False`. As written currently, `bool` is automatically inferred as non-required, which necessitates there be a default.

I'm not sure whether I think this is ultimately preferable to removing the `required=False` inference, and instead having the behavior that the defaultedness of the field is the only indicator of whether it's required.

The reason that was introduced in the first place was because `--bool`, as a simple flag can **only** set something to `True`, and having it be required by default may be somewhat weird. However you certainly **can** specify `Annotated[bool, Arg(long=['--bool', '--no-bool'])]` and arrive at a place where a required bool **might** make sense.

It just generally feels to me that required options are kind of stupid in any case...