### PR TITLE
fix: Handle TypeError in mapping failure also.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cappa"
-version = "0.14.2"
+version = "0.14.3"
 description = "Declarative CLI argument parser."
 
 repository = "https://github.com/dancardin/cappa"

--- a/src/cappa/annotation.py
+++ b/src/cappa/annotation.py
@@ -144,7 +144,7 @@ def parse_union(*type_args: type) -> typing.Callable[[typing.Any], typing.Any]:
         for mapper in mappers:
             try:
                 return mapper(value)
-            except ValueError:
+            except (ValueError, TypeError):
                 pass
 
         raise ValueError(

--- a/tests/arg/test_mapping_failure.py
+++ b/tests/arg/test_mapping_failure.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Union
 
 import cappa
 import pytest
+from typing_extensions import Annotated
 
 from tests.utils import backends, parse
 
@@ -22,3 +25,16 @@ def test_default(backend):
         e.value.message
         == "Invalid value for 'default' with value 'foo': invalid literal for int() with base 10: 'foo'"
     )
+
+
+@backends
+def test_other_exception_types(backend):
+    @dataclass
+    class ArgTest:
+        path: Annotated[Union[Path, None], cappa.Arg(long=True)] = None
+
+    result = parse(ArgTest, backend=backend)
+    assert result.path is None
+
+    result = parse(ArgTest, "--path", "asdf", backend=backend)
+    assert result.path == Path("asdf")


### PR DESCRIPTION
Apparently Path constructor can yield TypeError.

It may be that we should just catch all exceptions here...erring on the side of caution for now.