### PR TITLE
feat: Support `Dep` on function based commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.16
 
+### 0.16.1
+
+- feat: Support `Dep` on function based commands.
+
 ### 0.16.0
 
 - feat: Add support for `BinaryIO` and `TextIO` for representing preconfigured

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cappa"
-version = "0.16.0"
+version = "0.16.1"
 description = "Declarative CLI argument parser."
 
 repository = "https://github.com/dancardin/cappa"

--- a/src/cappa/invoke.py
+++ b/src/cappa/invoke.py
@@ -264,7 +264,7 @@ def resolve_implicit_deps(command: Command, instance: HasCommand) -> dict:
 def fullfill_deps(fn: Callable, fullfilled_deps: dict) -> typing.Any:
     result = {}
 
-    signature = inspect.signature(fn)
+    signature = getattr(fn, "__signature__", None) or inspect.signature(fn)
     try:
         annotations = get_type_hints(fn, include_extras=True)
     except NameError as e:  # pragma: no cover

--- a/src/cappa/typing.py
+++ b/src/cappa/typing.py
@@ -111,8 +111,9 @@ def is_subclass(typ, superclass):
 def get_type_hints(obj, include_extras=False):
     result = typing_extensions.get_type_hints(obj, include_extras=include_extras)
     if sys.version_info < (3, 11):  # pragma: no cover
-        return fix_annotated_optional_type_hints(result)
-    return result
+        result = fix_annotated_optional_type_hints(result)
+
+    return {k: v for k, v in result.items() if k not in {"return"}}
 
 
 def fix_annotated_optional_type_hints(

--- a/tests/command/test_function_command.py
+++ b/tests/command/test_function_command.py
@@ -73,3 +73,22 @@ def test_subcommand(backend):
 
     result = invoke(function, "sub", "--bar", "34", backend=backend)
     assert result == 35
+
+
+def foo():
+    return 5
+
+
+@backends
+def test_invoke_partial_arg_partial_dep(backend):
+    def function(
+        dep: Annotated[int, cappa.Dep(foo)],
+        foo: Annotated[int, cappa.Arg(long=True)] = 15,
+    ):
+        return dep + foo
+
+    result = invoke(function, backend=backend)
+    assert result == 20
+
+    result = invoke(function, "--foo", "53", backend=backend)
+    assert result == 58


### PR DESCRIPTION
Previously all args were translated to dataclass fields, i.e. CLI inputs, and `Dep`s would not be fullfilled