### PR TITLE
fix: Add better sequence inference.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## 0.17
 
+### 0.17.1
+
+- Fixes bounded-tuple options like `tuple[str, str]` to infer as `num_args=2`
+- Fixes bounded-tuple options to fail parsing if you give it a different number
+  of values
+- Fixes "double sequence" inference on explicit `num_args=N` values which would
+  produce sequences. I.e. infer `action=ArgAction.set` in such cases to avoid
+  e.x. `num_args=3, action=ArgAction.append`; resulting in nonsensical nested
+  sequence `["[]"]`
+
 ### 0.17.0
 
 - feat: Add `hidden=True/False` option to Command, which allows hiding

--- a/docs/source/annotation.md
+++ b/docs/source/annotation.md
@@ -122,6 +122,12 @@ Annotations like `list[...]`, `set[...]`, `tuple[...]`, etc are what we call
   assert prog == Prog(foo=['foo', 'bar', 'baz'])
   ```
 
+  ```{note}
+  You can specify `Annotated[list[str], Arg(short=True, num_args=n)]` where
+  `n` would yield a sequence (`-1` or > 1). In such a case, `action` would instead
+  be inferred as `ArgAction.set`.
+  ```
+
 See [Argument](./arg.md) for more details on the difference between
 `ArgAction.append` and `num_args=-1`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cappa"
-version = "0.17.0"
+version = "0.17.1"
 description = "Declarative CLI argument parser."
 
 repository = "https://github.com/dancardin/cappa"

--- a/src/cappa/parser.py
+++ b/src/cappa/parser.py
@@ -484,16 +484,8 @@ def consume_arg(
         result = []
         while num_args:
             if isinstance(context.peek_value(), RawOption):
-                if orig_num_args < 0:
-                    break
+                break
 
-                raise BadArgumentError(
-                    f"Argument requires {orig_num_args} values, "
-                    f"only found {len(result)} ('{' '.join(result)}' so far)",
-                    value=result,
-                    command=context.command,
-                    arg=arg,
-                )
             try:
                 next_val = typing.cast(RawArg, context.next_value())
             except IndexError:
@@ -535,6 +527,20 @@ def consume_arg(
             raise BadArgumentError(
                 f"Option '{arg.value_name}' requires an argument",
                 value="",
+                command=context.command,
+                arg=arg,
+            )
+    else:
+        if orig_num_args > 0 and len(result) != orig_num_args:
+            quoted_result = [f"'{r}'" for r in result]
+            names_str = arg.names_str("/")
+
+            message = f"Argument '{names_str}' requires {orig_num_args} values, found {len(result)}"
+            if quoted_result:
+                message += f" ({', '.join(quoted_result)} so far)"
+            raise BadArgumentError(
+                message,
+                value=result,
                 command=context.command,
                 arg=arg,
             )

--- a/tests/arg/test_tuple.py
+++ b/tests/arg/test_tuple.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+import cappa
+import pytest
+from typing_extensions import Annotated
+
 from tests.utils import backends, parse
 
 
@@ -14,3 +18,38 @@ class ArgTest:
 def test_valid(backend):
     test = parse(ArgTest, "1", "2", "3.4", backend=backend)
     assert test.numbers == (1, "2", 3.4)
+
+
+@backends
+def test_tuple_option(backend):
+    @dataclass
+    class Example:
+        start_project: Annotated[
+            tuple[int, float],
+            cappa.Arg(short=True, default=(1, 9), required=False),
+        ]
+
+    test = parse(Example, backend=backend)
+    assert test == Example(start_project=(1, 9))
+
+    test = parse(Example, "-s", "2", "2.4", backend=backend)
+    assert test == Example(start_project=(2, 2.4))
+
+    # Missing values
+    with pytest.raises(cappa.Exit) as e:
+        parse(Example, "-s", "1", backend=backend)
+
+    assert e.value.code == 2
+
+    if backend:
+        assert str(e.value.message).lower() == "argument -s: expected 2 arguments"
+    else:
+        assert (
+            e.value.message == "Argument '-s' requires 2 values, found 1 ('1' so far)"
+        )
+
+    # Extra values
+    with pytest.raises(cappa.Exit) as e:
+        parse(Example, "-s", "1", "2", "3", backend=backend)
+    assert e.value.code == 2
+    assert e.value.message == "Unrecognized arguments: 3"

--- a/tests/parser/test_missing_num_args.py
+++ b/tests/parser/test_missing_num_args.py
@@ -25,4 +25,4 @@ def test_invalid_choice_help(backend):
     if backend == argparse.backend:
         assert "The following arguments are required: arg" in message
     else:
-        assert message == "Argument requires 2 values, only found 1 ('arg' so far)"
+        assert message == "Argument 'arg arg' requires 2 values, found 1 ('arg' so far)"

--- a/tests/parser/test_num_args.py
+++ b/tests/parser/test_num_args.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 import cappa
@@ -25,3 +27,34 @@ def test_single_opt(backend):
 
     assert e.value.message is None
     assert e.value.code == 0
+
+
+@backends
+def test_num_args_list(backend):
+    @dataclass
+    class Args:
+        foo: Annotated[
+            list[str],
+            cappa.Arg(
+                short=True,
+                default=["", ""],
+                required=False,
+                num_args=2,
+            ),
+        ]
+
+    args = parse(Args, backend=backend)
+    assert args == Args(["", ""])
+
+    args = parse(Args, "-f", "2", "4", backend=backend)
+    assert args == Args(["2", "4"])
+
+    with pytest.raises(cappa.Exit) as e:
+        parse(Args, "-f", backend=backend)
+
+    assert e.value.code == 2
+
+    if backend:
+        assert str(e.value.message).lower() == "argument -f: expected 2 arguments"
+    else:
+        assert e.value.message == "Argument '-f' requires 2 values, found 0"


### PR DESCRIPTION
* Fixes bounded-tuple options like `tuple[str, str]` to infer as `num_args=2`
* Fixes bounded-tuple options to fail parsing if you give it a different number of values
* Fixes "double sequence" inference on explicit `num_args=N` values which would produce sequences. I.e. infer `action=ArgAction.set` in such cases to avoid e.x. `num_args=3, action=ArgAction.append`; resulting in nonsensical nested sequence `["[]"]`

Fixes https://github.com/DanCardin/cappa/issues/106

What does concern me slightly is that this allows something which was previously erroneous to specify:

```python
class Foo:
    foo: Annotated[list[str], cappa.Arg(num_args=1, short=True)]
```
This was erroring because failed because the `num_args=1` implied a non-sequence type. However the inferred `action=ArgAction.append` **should** yield a list, and thus this **seems** okay

and

```
class Foo:
    foo: Annotated[list[str], cappa.Arg(num_args=2, short=True)]
```
This was failing weirdly because action inferred as `action=ArgAction.append`, and num_args=2 also yields a list. So together, they'd produce a nested list and surprising behavior. **now** the explicit num_args causes action to infer as `ArgAction.set`, which...also seems logical.