### PR TITLE
chore: update typing-extensions to `>=4.8.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.17
 
+### 0.17.2
+
+- Increase minimum typing_extensions bound to reflect actual dependency.
+
 ### 0.17.1
 
 - Fixes bounded-tuple options like `tuple[str, str]` to infer as `num_args=2`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ include = [
 [tool.poetry.dependencies]
 python = ">=3.8,<4"
 
-typing-extensions = ">=4.7.1"
+typing-extensions = ">=4.8.0"
 typing-inspect = ">=0.9.0"
 rich = "*"
 eval_type_backport = {version = "*", python = "<3.10"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cappa"
-version = "0.17.1"
+version = "0.17.2"
 description = "Declarative CLI argument parser."
 
 repository = "https://github.com/dancardin/cappa"


### PR DESCRIPTION
PEP 727 was added in typing-extensions 4.8.0. 

Https://github.com/python/typing_extensions/blob/main/CHANGELOG.md