### PR TITLE
fix: default=Env(...) takes precedence over class default, when env v…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.17
 
+### 0.17.3
+
+- fix: Ensure class default combined with `default=Env(...)` still attempts to
+  read env var (rather than just unconditionally taking the class default).
+
 ### 0.17.2
 
 - Increase minimum typing_extensions bound to reflect actual dependency.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cappa"
-version = "0.17.2"
+version = "0.17.3"
 description = "Declarative CLI argument parser."
 
 repository = "https://github.com/dancardin/cappa"

--- a/src/cappa/arg.py
+++ b/src/cappa/arg.py
@@ -297,13 +297,14 @@ def infer_field_name(arg: Arg, field: Field) -> str:
 def infer_default(arg: Arg, field: Field, annotation: type) -> typing.Any:
     if arg.default is not missing:
         # Annotated[str, Env('FOO')] = "bar" should produce "bar". I.e. the field default
-        # should be used if the `Env` default is not set.
+        # should be used if the `Env` default is not set, but still attempt to read the
+        # `Env` if it **is** set.
         if (
             isinstance(arg.default, Env)
             and arg.default.default is None
             and field.default is not missing
         ):
-            return field.default
+            return Env(*arg.default.env_vars, default=field.default)
 
         return arg.default
 

--- a/tests/arg/test_env.py
+++ b/tests/arg/test_env.py
@@ -58,3 +58,14 @@ def test_class_default_gets_applied_to_env_default(backend):
 
     test = parse(ArgTest, backend=backend)
     assert test.default == "wat"
+
+
+@backends
+def test_class_default_still_abides_env_var(backend):
+    @dataclass
+    class ArgTest:
+        default: Annotated[str, cappa.Arg(default=cappa.Env("ASDF"))] = "wat"
+
+    with patch("os.environ", new={"ASDF": "foo"}):
+        test = parse(ArgTest, backend=backend)
+    assert test.default == "foo"


### PR DESCRIPTION
…ar exists.