### PR TITLE
feat: Add `default_short=False` and `default_long=False` options to command for ease of definining option-heavy commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.18
+
+### 0.18.0
+
+- feat: Add `default_short=False` and `default_long=False` options to command
+  for ease of definining option-heavy commands.
+
 ## 0.17
 
 ### 0.17.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cappa"
-version = "0.17.3"
+version = "0.18.0"
 description = "Declarative CLI argument parser."
 
 repository = "https://github.com/dancardin/cappa"

--- a/src/cappa/base.py
+++ b/src/cappa/base.py
@@ -248,6 +248,8 @@ def command(
     description: str | None = None,
     invoke: typing.Callable | str | None = None,
     hidden: bool = False,
+    default_short: bool = False,
+    default_long: bool = False,
 ):
     """Register a cappa CLI command/subcomment.
 
@@ -265,6 +267,10 @@ def command(
             function to invoke.
         hidden: If `True`, the command will not be included in the help output.
             This option is only relevant to subcommands.
+        default_short: If `True`, all arguments will be treated as though annotated
+            with `Annotated[T, Arg(short=True)]`, unless otherwise annotated.
+        default_long: If `True`, all arguments will be treated as though annotated
+            with `Annotated[T, Arg(long=True)]`, unless otherwise annotated.
     """
 
     def wrapper(_decorated_cls):
@@ -278,6 +284,8 @@ def command(
             help=help,
             description=description,
             hidden=hidden,
+            default_short=default_short,
+            default_long=default_long,
         )
         _decorated_cls.__cappa__ = instance
         return _decorated_cls

--- a/src/cappa/parser.py
+++ b/src/cappa/parser.py
@@ -154,13 +154,15 @@ class ParseContext:
                     unique_names.add(arg.field_name)
                 result[arg.field_name] = arg
 
-            assert arg.short is not True
-            for short in arg.short or []:
-                result[short] = arg
+            for opts in (arg.short, arg.long):
+                if not opts:
+                    continue
 
-            assert arg.long is not True
-            for long in arg.long or []:
-                result[long] = arg
+                for key in typing.cast(typing.List[str], opts):
+                    if key in result:
+                        raise ValueError(f"Conflicting option string: {key}")
+
+                    result[key] = arg
 
         return result, unique_names
 

--- a/tests/arg/test_default_long.py
+++ b/tests/arg/test_default_long.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import cappa
+import pytest
+from typing_extensions import Annotated
+
+from tests.utils import backends, parse
+
+
+@backends
+def test_valid(backend):
+    @cappa.command(default_long=True)
+    @dataclass
+    class Command:
+        foo: int = 4
+        bar: int = 5
+
+    test = parse(Command, backend=backend)
+    assert test == Command(4, 5)
+
+    test = parse(Command, "--foo", "1", "--bar", "2", backend=backend)
+    assert test == Command(1, 2)
+
+
+@backends
+def test_override(backend):
+    @cappa.command(default_long=True)
+    @dataclass
+    class Command:
+        foo: int
+        far: Annotated[int, cappa.Arg(long="--kar")]
+
+    test = parse(Command, "--foo", "1", "--kar", "2", backend=backend)
+    assert test == Command(1, 2)
+
+
+@backends
+def test_invalid(backend):
+    @cappa.command(default_long=True)
+    @dataclass
+    class Command:
+        foo: int
+        far: Annotated[int, cappa.Arg(long="--foo")]
+
+    with pytest.raises(Exception) as e:
+        parse(Command, backend=backend)
+    assert "conflicting option string: --f" in str(e.value).lower()

--- a/tests/arg/test_default_short.py
+++ b/tests/arg/test_default_short.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import cappa
+import pytest
+from typing_extensions import Annotated
+
+from tests.utils import backends, parse
+
+
+@backends
+def test_valid(backend):
+    @cappa.command(default_short=True)
+    @dataclass
+    class Command:
+        foo: int = 4
+        bar: int = 5
+
+    test = parse(Command, backend=backend)
+    assert test == Command(4, 5)
+
+    test = parse(Command, "-f", "1", "-b", "2", backend=backend)
+    assert test == Command(1, 2)
+
+
+@backends
+def test_override(backend):
+    @cappa.command(default_short=True)
+    @dataclass
+    class Command:
+        foo: int
+        far: Annotated[int, cappa.Arg(short="-k")]
+
+    test = parse(Command, "-f", "1", "-k", "2", backend=backend)
+    assert test == Command(1, 2)
+
+
+@backends
+def test_invalid(backend):
+    @cappa.command(default_short=True)
+    @dataclass
+    class Command:
+        foo: int
+        far: int
+
+    with pytest.raises(Exception) as e:
+        parse(Command, backend=backend)
+    assert "conflicting option string: -f" in str(e.value).lower()

--- a/tests/help/test_line_wrapping.py
+++ b/tests/help/test_line_wrapping.py
@@ -22,7 +22,7 @@ def test_line_wraps_correctly_with_terminal_escape_codes(capsys):
         e: Annotated[str, cappa.Arg(short=True)]
         f: Annotated[str, cappa.Arg(short=True)]
         g: Annotated[str, cappa.Arg(short=True)]
-        h: Annotated[str, cappa.Arg(short=True)]
+        i: Annotated[str, cappa.Arg(short=True)]
 
     columns = 80
     env = {
@@ -38,6 +38,6 @@ def test_line_wraps_correctly_with_terminal_escape_codes(capsys):
     out = capsys.readouterr().out
     plain, *_ = Text.from_ansi(out).plain.splitlines()
 
-    expected = "Usage: args -a A -b B -c C -d D -e E -f F -g G -h H [-h] [--completion"
+    expected = "Usage: args -a A -b B -c C -d D -e E -f F -g G -i I [-h] [--completion"
     assert len(expected) < columns
     assert plain == expected


### PR DESCRIPTION
i.e. 

```python
    @cappa.command(default_long=True)
    class Command:
        foo: int = 4
        bar: int = 5
```

results in `--foo` and `--bar` rather than `FOO BAR` positional arguments