### PR TITLE
feat: Add deprecated option to command/arg.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,20 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         pydantic-version: ["1.0", "2.0"]
 
+        # No need to matrix test pydantic versions. But the matrix syntax still
+        # keeps the file DRY.
+        exclude:
+         - python-version: '3.8'
+           pydantic-version: '1.0'
+         - python-version: '3.9'
+           pydantic-version: '1.0'
+         - python-version: '3.11'
+           pydantic-version: '1.0'
+         - python-version: '3.12'
+           pydantic-version: '1.0'
+         - python-version: '3.13-dev'
+           pydantic-version: '1.0'
+
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -51,6 +65,7 @@ jobs:
 
       - name: Run Linters
         run: poetry run make lint
+        if: ${{ !endsWith(matrix.python-version, '-dev') }}
 
       - name: Run tests
         run: poetry run make test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cappa"
-version = "0.18.0"
+version = "0.18.1"
 description = "Declarative CLI argument parser."
 
 repository = "https://github.com/dancardin/cappa"

--- a/src/cappa/arg.py
+++ b/src/cappa/arg.py
@@ -1,4 +1,5 @@
 """Define the external facing argument definition types provided by a user."""
+
 from __future__ import annotations
 
 import dataclasses
@@ -105,14 +106,15 @@ class Arg(typing.Generic[T]):
         choices: Generally automatically inferred from the data type. This allows to
             override the default.
         completion: Used to provide custom completions. If specified, should be a function
-            which acccepts a partial string value and returns a list of
+            which accepts a partial string value and returns a list of
             [cappa.Completion](cappa.Completion) objects.
-
         required: Defaults to automatically inferring requiredness, based on whether the
             class's value has a default. By setting this, you can force a particular value.
-
         field_name: The name of the class field to populate with this arg. In most usecases,
             this field should be left unspecified and automatically inferred.
+        deprecated: If supplied, the argument will be marked as deprecated. If given `True`,
+            a default message will be generated, otherwise a supplied string will be
+            used as the deprecation message.
     """
 
     value_name: str | MISSING = missing
@@ -130,10 +132,9 @@ class Arg(typing.Generic[T]):
     num_args: int | None = None
     choices: list[str] | None = None
     completion: Callable[..., list[Completion]] | None = None
-
     required: bool | None = None
-
     field_name: str | MISSING = missing
+    deprecated: bool | str = False
 
     annotations: list[type] = dataclasses.field(default_factory=list)
 
@@ -157,7 +158,7 @@ class Arg(typing.Generic[T]):
         if object_annotation.doc:
             fallback_help = object_annotation.doc
 
-        # Dataclass field metatdata takes precedence if it exists.
+        # Dataclass field metadata takes precedence if it exists.
         field_metadata = extract_dataclass_metadata(field)
         assert not isinstance(field_metadata, Subcommand)
 

--- a/src/cappa/base.py
+++ b/src/cappa/base.py
@@ -99,7 +99,7 @@ def invoke(
     Arguments:
         obj: A class which can represent a CLI command chain.
         deps: Optional extra depdnencies to load ahead of invoke processing. These
-            deps are evaulated in order and unconditionally.
+            deps are evaluated in order and unconditionally.
         argv: Defaults to the process argv. This command is generally only
             necessary when testing.
         backend: A function used to perform the underlying parsing and return a raw
@@ -165,7 +165,7 @@ async def invoke_async(
     Arguments:
         obj: A class which can represent a CLI command chain.
         deps: Optional extra depdnencies to load ahead of invoke processing. These
-            deps are evaulated in order and unconditionally.
+            deps are evaluated in order and unconditionally.
         argv: Defaults to the process argv. This command is generally only
             necessary when testing.
         backend: A function used to perform the underlying parsing and return a raw
@@ -250,6 +250,7 @@ def command(
     hidden: bool = False,
     default_short: bool = False,
     default_long: bool = False,
+    deprecated: bool = False,
 ):
     """Register a cappa CLI command/subcomment.
 
@@ -271,6 +272,9 @@ def command(
             with `Annotated[T, Arg(short=True)]`, unless otherwise annotated.
         default_long: If `True`, all arguments will be treated as though annotated
             with `Annotated[T, Arg(long=True)]`, unless otherwise annotated.
+        deprecated: If supplied, the argument will be marked as deprecated. If given `True`,
+            a default message will be generated, otherwise a supplied string will be
+            used as the deprecation message.
     """
 
     def wrapper(_decorated_cls):
@@ -286,6 +290,7 @@ def command(
             hidden=hidden,
             default_short=default_short,
             default_long=default_long,
+            deprecated=deprecated,
         )
         _decorated_cls.__cappa__ = instance
         return _decorated_cls

--- a/src/cappa/command.py
+++ b/src/cappa/command.py
@@ -63,6 +63,9 @@ class Command(typing.Generic[T]):
             with `Annotated[T, Arg(short=True)]`, unless otherwise annotated.
         default_true: If `True`, all arguments will be treated as though annotated
             with `Annotated[T, Arg(long=True)]`, unless otherwise annotated.
+        deprecated: If supplied, the argument will be marked as deprecated. If given `True`,
+            a default message will be generated, otherwise a supplied string will be
+            used as the deprecation message.
     """
 
     cmd_cls: type[T]
@@ -75,6 +78,7 @@ class Command(typing.Generic[T]):
     hidden: bool = False
     default_short: bool = False
     default_long: bool = False
+    deprecated: bool | str = False
 
     _collected: bool = False
 

--- a/tests/arg/test_deprecated.py
+++ b/tests/arg/test_deprecated.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import sys
+import textwrap
+from dataclasses import dataclass
+
+import cappa
+import pytest
+from typing_extensions import Annotated
+
+from tests.utils import parse
+
+
+def test_native_backend(capsys):
+    @dataclass
+    class ArgTest:
+        arg1: Annotated[str, cappa.Arg(deprecated=True)] = "default"
+        arg2: Annotated[
+            str, cappa.Arg(short="a", long="--aaaa", deprecated=True)
+        ] = "default"
+        arg3: Annotated[
+            str, cappa.Arg(short="b", deprecated="Use something else")
+        ] = "default"
+
+    result = parse(ArgTest)
+    assert result.arg1 == "default"
+    assert result.arg2 == "default"
+    assert result.arg3 == "default"
+    err = capsys.readouterr().err
+    assert err == ""
+
+    result = parse(ArgTest, "a")
+    assert result.arg1 == "a"
+    err = capsys.readouterr().err
+    assert err == "Error: Argument `arg1` is deprecated\n"
+
+    result = parse(ArgTest, "-a", "1")
+    assert result.arg2 == "1"
+    err = capsys.readouterr().err
+    assert err == "Error: Option `-a` is deprecated\n"
+
+    result = parse(ArgTest, "-b", "1")
+    assert result.arg3 == "1"
+    err = capsys.readouterr().err
+    assert err == "Error: Option `-b` is deprecated: Use something else\n"
+
+
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason="requires python3.13 or higher")
+def test_argparse_le_313(capsys):
+    """Below 3.13, this option has no effect."""
+
+    @dataclass
+    class ArgTest:
+        arg1: Annotated[str, cappa.Arg(deprecated=True)] = "default"
+        arg2: Annotated[
+            str, cappa.Arg(short="a", long="--aaaa", deprecated=True)
+        ] = "default"
+        arg3: Annotated[
+            str, cappa.Arg(short="b", deprecated="Use something else")
+        ] = "default"
+
+    result = parse(ArgTest, backend=cappa.argparse.backend)
+    assert result.arg1 == "default"
+    assert result.arg2 == "default"
+    assert result.arg3 == "default"
+    err = capsys.readouterr().err
+    assert err == ""
+
+    result = parse(ArgTest, "1", "-a", "1", "-b", "1", backend=cappa.argparse.backend)
+    assert result.arg1 == "1"
+    assert result.arg1 == "1"
+    assert result.arg1 == "1"
+    err = capsys.readouterr().err
+    assert err == ""
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 13), reason="Below 3.13, the behavior is different"
+)
+def test_argparse_ge_313(capsys):
+    @dataclass
+    class ArgTest:
+        arg1: Annotated[str, cappa.Arg(deprecated=True)] = "default"
+        arg2: Annotated[
+            str, cappa.Arg(short="a", long="--aaaa", deprecated=True)
+        ] = "default"
+        arg3: Annotated[
+            str, cappa.Arg(short="b", deprecated="Use something else")
+        ] = "default"
+
+    result = parse(ArgTest, backend=cappa.argparse.backend)
+    assert result.arg1 == "default"
+    assert result.arg2 == "default"
+    assert result.arg3 == "default"
+    err = capsys.readouterr().err
+    assert err == ""
+
+    result = parse(ArgTest, "1", "-a", "1", "-b", "1", backend=cappa.argparse.backend)
+    assert result.arg1 == "1"
+    assert result.arg1 == "1"
+    assert result.arg1 == "1"
+    err = capsys.readouterr().err
+    assert err == textwrap.dedent(
+        """\
+        warning: argument 'arg1' is deprecated
+        warning: option '-a' is deprecated
+        warning: option '-b' is deprecated
+        """
+    )

--- a/tests/subcommand/test_deprecated.py
+++ b/tests/subcommand/test_deprecated.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+
+import cappa
+import pytest
+
+from tests.utils import parse
+
+
+@cappa.command(deprecated=True)
+@dataclass
+class Sub:
+    pass
+
+
+@dataclass
+class ArgTest:
+    sub: cappa.Subcommands[Sub | None] = None
+
+
+def test_native_backend(capsys):
+    """Note, argparse only support deprecated at or above 3.13."""
+    result = parse(ArgTest)
+    assert result.sub is None
+    err = capsys.readouterr().err
+    assert err == ""
+
+    result = parse(ArgTest, "sub")
+    assert result.sub == Sub()
+    err = capsys.readouterr().err
+    assert err == "Error: Command `sub` is deprecated\n"
+
+
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason="requires python3.13 or higher")
+def test_argparse_le_313(capsys):
+    """Below 3.13, this option has no effect."""
+    result = parse(ArgTest, backend=cappa.argparse.backend)
+    assert result.sub is None
+    err = capsys.readouterr().err
+    assert err == ""
+
+    result = parse(ArgTest, "sub", backend=cappa.argparse.backend)
+    assert result.sub == Sub()
+    err = capsys.readouterr().err
+    assert err == ""
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 13), reason="Below 3.13, the behavior is different"
+)
+def test_argparse_ge_313(capsys):
+    result = parse(ArgTest, backend=cappa.argparse.backend)
+    assert result.sub is None
+    err = capsys.readouterr().err
+    assert err == ""
+
+    result = parse(ArgTest, "sub", backend=cappa.argparse.backend)
+    assert result.sub == Sub()
+    err = capsys.readouterr().err
+    assert err == "warning: command 'sub' is deprecated"


### PR DESCRIPTION
Note argparse only supports this option since python 3.13. The way argparse is implemented, it seems like it'd be nontrivial to backport, so for now it's going to do nothing in versions that dont support it.