### PR TITLE
fix: handle missing pydantic-core corner case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.19
 
+### 0.19.1
+
+- fix: Eagerly attempt pydantic BaseModel import to ensure its skipped if unavailable.
+
 ### 0.19.0
 
 - feat: Add support for `msgspec` based class definitions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cappa"
-version = "0.19.0"
+version = "0.19.1"
 description = "Declarative CLI argument parser."
 
 repository = "https://github.com/dancardin/cappa"

--- a/src/cappa/class_inspect.py
+++ b/src/cappa/class_inspect.py
@@ -186,13 +186,14 @@ class ClassTypes(Enum):
             return cls.msgspec
 
         try:
+            from pydantic import BaseModel
             import pydantic
         except ImportError:  # pragma: no cover
             pass
         else:
             try:
                 is_base_model = isinstance(obj, type) and issubclass(
-                    obj, pydantic.BaseModel
+                    obj, BaseModel
                 )
             except TypeError:  # pragma: no cover
                 is_base_model = False

--- a/src/cappa/class_inspect.py
+++ b/src/cappa/class_inspect.py
@@ -186,15 +186,13 @@ class ClassTypes(Enum):
             return cls.msgspec
 
         try:
-            from pydantic import BaseModel
             import pydantic
+            from pydantic import BaseModel
         except ImportError:  # pragma: no cover
             pass
         else:
             try:
-                is_base_model = isinstance(obj, type) and issubclass(
-                    obj, BaseModel
-                )
+                is_base_model = isinstance(obj, type) and issubclass(obj, BaseModel)
             except TypeError:  # pragma: no cover
                 is_base_model = False
 


### PR DESCRIPTION
This change handles a corner case where `pydantic` is installed in the environment but `pydantic-core` is missing. The current code assumes that if pydantic is importable, then pydantic is available, but the access of `pydantic.BaseModel` does [a lazy import](https://github.com/pydantic/pydantic/blob/7061f36bc721ef4f173ef8f2e098f25e1eaea705/pydantic/__init__.py#L383-L396) of `pydantic-core` which is not handled, crashing the application that is using `cappa`. 

To handle the issue, `BaseModel` is imported eagerly during the detection step, which will throw an error when `pydantic-core` is not available. 

I have observed this in the wild, where I am not using `pydantic` with cappa at all, nor it is one of my direct dependencies, but it is still being pulled transitively from other sources, crashing my application. This issue surfaced with https://github.com/DanCardin/cappa/releases/tag/v0.19.0.