### PR TITLE
refactor: Adopt the type-lens package.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,19 +6,19 @@ install:
 	uv sync --all-extras
 
 test:
-	uv run --all-extras coverage run -m pytest src tests
-	uv run coverage combine
-	uv run coverage report
-	uv run coverage xml
+	uv run --no-sync --all-extras coverage run -m pytest src tests
+	uv run --no-sync coverage combine
+	uv run --no-sync coverage report
+	uv run --no-sync coverage xml
 
 lint:
-	uv run ruff check src tests examples || exit 1
-	uv run --all-extras mypy src tests examples || exit 1
-	uv run ruff format --check src tests examples || exit 1
+	uv run --no-sync ruff check src tests examples || exit 1
+	uv run --no-sync --all-extras mypy src tests examples || exit 1
+	uv run --no-sync ruff format --check src tests examples || exit 1
 
 format:
-	uv run ruff check src tests examples --fix
-	uv run ruff format src tests examples
+	uv run --no-sync ruff check src tests examples --fix
+	uv run --no-sync ruff format src tests examples
 
 readme-image:
-	FORCE_COLOR=true uv run python readme.py --help | ansitoimg --title '' docs/source/_static/example.svg
+	FORCE_COLOR=true uv run --no-sync python readme.py --help | ansitoimg --title '' docs/source/_static/example.svg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,11 @@ dependencies = [
   "typing-inspect >= 0.9.0",
   "rich",
   "eval_type_backport; python_version < '3.10'",
+  "type-lens",
 ]
+
+[tool.uv.sources]
+type-lens = { git = "https://github.com/dancardin/type-lens", branch = "dc/subclass_of"}
 
 [project.optional-dependencies]
 docstring = ["docstring-parser >= 0.15"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,15 +27,10 @@ include = [
 requires-python = ">=3.8,<4"
 
 dependencies = [
-  "typing-extensions >= 4.8.0",
-  "typing-inspect >= 0.9.0",
   "rich",
-  "eval_type_backport; python_version < '3.10'",
-  "type-lens",
+  "typing-extensions >= 4.8.0",
+  "type-lens >= 0.2.2",
 ]
-
-[tool.uv.sources]
-type-lens = { git = "https://github.com/dancardin/type-lens", branch = "dc/subclass_of"}
 
 [project.optional-dependencies]
 docstring = ["docstring-parser >= 0.15"]
@@ -47,7 +42,6 @@ dev-dependencies = [
   "mypy >= 1.0.0",
   "ruff >= 0.6.2",
   "docutils >= 0.20.0",
-  "typing-extensions >= 4.8.0",
   "types-docutils >= 0.20.0",
 
   "attrs",

--- a/src/cappa/arg.py
+++ b/src/cappa/arg.py
@@ -7,7 +7,7 @@ import enum
 import typing
 from collections.abc import Callable
 
-from typing_inspect import is_optional_type
+from type_lens import TypeView
 
 from cappa.class_inspect import Field, extract_dataclass_metadata
 from cappa.completion.completers import complete_choices
@@ -16,15 +16,10 @@ from cappa.env import Env
 from cappa.parse import parse_optional, parse_value
 from cappa.typing import (
     MISSING,
-    NoneType,
+    Doc,
     T,
     detect_choices,
-    find_type_annotation,
-    get_optional_type,
-    is_of_type,
-    is_sequence_type,
-    is_subclass,
-    is_union_type,
+    find_annotations,
     missing,
 )
 
@@ -153,42 +148,36 @@ class Arg(typing.Generic[T]):
     def collect(
         cls,
         field: Field,
-        type_hint: type,
+        type_view: TypeView,
         fallback_help: str | None = None,
         default_short: bool = False,
         default_long: bool = False,
     ) -> list[Arg]:
-        object_annotation = find_type_annotation(type_hint, cls)
-        annotation = object_annotation.annotation
-
-        result = []
-
-        args = object_annotation.obj
-        if not args:
-            args = [cls()]
+        args = find_annotations(type_view, cls) or [DEFAULT_ARG]
 
         exclusive = len(args) > 1
 
+        docs = find_annotations(type_view, Doc)
+        fallback_help = docs[0].documentation if docs else fallback_help
+
+        # Dataclass field metadata takes precedence if it exists.
+        field_metadata = extract_dataclass_metadata(field, Arg)
+        if field_metadata:
+            args = field_metadata
+
+        result = []
         for arg in args:
-            if object_annotation.doc:
-                fallback_help = object_annotation.doc
-
-            # Dataclass field metadata takes precedence if it exists.
-            field_metadata = extract_dataclass_metadata(field, Arg)
-            if field_metadata:
-                arg = field_metadata
-
             field_name = infer_field_name(arg, field)
-            default = infer_default(arg, field, annotation)
+            default = infer_default(arg, field, type_view)
 
             arg = dataclasses.replace(
                 arg,
                 field_name=field_name,
                 default=default,
-                annotations=object_annotation.other_annotations,
+                annotations=list(type_view.metadata),
             )
             normalized_arg = arg.normalize(
-                annotation,
+                type_view,
                 fallback_help=fallback_help,
                 default_short=default_short,
                 default_long=default_long,
@@ -200,7 +189,7 @@ class Arg(typing.Generic[T]):
 
     def normalize(
         self,
-        annotation: typing.Any = NoneType,
+        annotation: TypeView | None = None,
         fallback_help: str | None = None,
         action: ArgAction | Callable | None = None,
         default: typing.Any = missing,
@@ -209,20 +198,20 @@ class Arg(typing.Generic[T]):
         default_long: bool = False,
         exclusive: bool = False,
     ) -> Arg:
-        origin = typing.get_origin(annotation) or annotation
-        type_args = typing.get_args(annotation)
+        if annotation is None:
+            annotation = TypeView(...)
 
         field_name = typing.cast(str, field_name or self.field_name)
         default = default if default is not missing else self.default
 
-        verify_type_compatibility(self, field_name, annotation, origin, type_args)
+        verify_type_compatibility(self, field_name, annotation)
         short = infer_short(self, field_name, default_short)
-        long = infer_long(self, origin, field_name, default_long)
+        long = infer_long(self, annotation, field_name, default_long)
         choices = infer_choices(self, annotation)
-        action = action or infer_action(
-            self, annotation, origin, type_args, long, default
-        )
-        num_args = infer_num_args(self, origin, type_args, action, long)
+        action = action or infer_action(self, annotation, long, default)
+        num_args = infer_num_args(self, annotation, action, long)
+        print("num_args", field_name, num_args)
+        print("num_args", field_name, action)
         required = infer_required(self, annotation, default)
 
         parse = infer_parse(self, annotation)
@@ -265,13 +254,7 @@ class Arg(typing.Generic[T]):
         return typing.cast(str, self.value_name)
 
 
-def verify_type_compatibility(
-    arg: Arg,
-    field_name: str,
-    annotation: type,
-    origin: type,
-    type_args: tuple[type, ...],
-):
+def verify_type_compatibility(arg: Arg, field_name: str, annotation: TypeView):
     """Verify classes of annotations are compatible with one another.
 
     Thus far:
@@ -286,9 +269,10 @@ def verify_type_compatibility(
     if arg.parse or ArgAction.is_custom(action):
         return
 
-    if is_union_type(origin):
+    if annotation.is_union:
         all_same_arity = {
-            is_sequence_type(ta) for ta in type_args if ta is not NoneType
+            ta.is_subclass_of((list, tuple, set))
+            for ta in annotation.strip_optional().inner_types
         }
         if len(all_same_arity) > 1:
             raise ValueError(
@@ -300,20 +284,18 @@ def verify_type_compatibility(
         return
 
     num_args = arg.num_args
-    # print(is_sequence_type(origin), num_args, action)
-    # print(f"  {num_args not in {0, 1} or action is ArgAction.append}")
-    if is_sequence_type(origin):
+    if annotation.is_subclass_of((list, tuple, set)):
         if num_args in {0, 1} and action not in {ArgAction.append, None}:
             raise ValueError(
                 f"On field '{field_name}', apparent mismatch of annotated type with `Arg` options. "
-                f"'{annotation}' type produces a sequence, whereas `num_args=1`/`action={action}` do not. "
+                f"'{annotation.annotation}' type produces a sequence, whereas `num_args=1`/`action={action}` do not. "
                 "See [documentation](https://cappa.readthedocs.io/en/latest/annotation.html) for more details."
             )
     else:
         if num_args not in {None, 0, 1} or action is ArgAction.append:
             raise ValueError(
                 f"On field '{field_name}', apparent mismatch of annotated type with `Arg` options. "
-                f"'{origin.__name__}' type produces a scalar, whereas `num_args={num_args}`/`action={action}` do not. "
+                f"'{annotation.annotation.__name__}' type produces a scalar, whereas `num_args={num_args}`/`action={action}` do not. "
                 "See [documentation](https://cappa.readthedocs.io/en/latest/annotation.html) for more details."
             )
 
@@ -325,7 +307,7 @@ def infer_field_name(arg: Arg, field: Field) -> str:
     return field.name
 
 
-def infer_default(arg: Arg, field: Field, annotation: type) -> typing.Any:
+def infer_default(arg: Arg, field: Field, annotation: TypeView) -> typing.Any:
     if arg.default is not missing:
         # Annotated[str, Env('FOO')] = "bar" should produce "bar". I.e. the field default
         # should be used if the `Env` default is not set, but still attempt to read the
@@ -345,21 +327,21 @@ def infer_default(arg: Arg, field: Field, annotation: type) -> typing.Any:
     if field.default_factory is not missing:
         return field.default_factory()
 
-    if is_optional_type(annotation):
+    if annotation.is_optional:
         return None
 
-    if is_subclass(annotation, bool):
+    if annotation.is_subclass_of(bool):
         return False
 
     return missing
 
 
-def infer_required(arg: Arg, annotation: type, default: typing.Any | MISSING):
+def infer_required(arg: Arg, annotation: TypeView, default: typing.Any | MISSING):
     if arg.required is True:
         return True
 
     if default is missing:
-        if is_subclass(annotation, bool) or is_optional_type(annotation):
+        if annotation.is_subclass_of(bool) or annotation.is_optional:
             return False
 
         if arg.required is False:
@@ -393,13 +375,13 @@ def infer_short(
 
 
 def infer_long(
-    arg: Arg, origin: type, name: str, default: bool
+    arg: Arg, annotation: TypeView, name: str, default: bool
 ) -> list[str] | typing.Literal[False]:
     long = arg.long or default
 
     if not long:
         # bools get automatically coerced into flags, otherwise stay off.
-        if not is_subclass(origin, bool):
+        if not annotation.is_subclass_of(bool):
             return False
 
         long = True
@@ -414,9 +396,9 @@ def infer_long(
     return [item if item.startswith("--") else f"--{item}" for item in long]
 
 
-def infer_choices(arg: Arg, annotation: type) -> list[str] | None:
+def infer_choices(arg: Arg, type_view: TypeView) -> list[str] | None:
     if arg.choices is None:
-        choices = detect_choices(annotation)
+        choices = detect_choices(type_view)
     else:
         choices = arg.choices
 
@@ -427,12 +409,7 @@ def infer_choices(arg: Arg, annotation: type) -> list[str] | None:
 
 
 def infer_action(
-    arg: Arg,
-    annotation: typing.Any,
-    origin: typing.Any,
-    type_args: tuple[type, ...],
-    long,
-    default: typing.Any,
+    arg: Arg, annotation: TypeView, long, default: typing.Any
 ) -> ArgAction | Callable:
     if arg.count:
         return ArgAction.count
@@ -440,12 +417,10 @@ def infer_action(
     if arg.action is not None:
         return arg.action
 
-    if is_optional_type(annotation):
-        annotation = get_optional_type(annotation)
-        origin = typing.get_origin(annotation) or annotation
+    annotation = annotation.strip_optional()
 
     # Coerce raw `bool` into flags by default
-    if is_subclass(origin, bool):
+    if annotation.is_subclass_of(bool):
         if isinstance(default, Env):
             default = default.default
 
@@ -458,6 +433,7 @@ def infer_action(
     has_specific_num_args = arg.num_args is not None
     unbounded_num_args = arg.num_args == -1
 
+    breakpoint()
     if (
         arg.parse
         or unbounded_num_args
@@ -466,21 +442,18 @@ def infer_action(
     ):
         return ArgAction.set
 
-    if is_of_type(annotation, (typing.List, typing.Set)):
+    if annotation.is_subclass_of((list, set)):
         return ArgAction.append
 
-    if is_of_type(annotation, typing.Tuple):
-        is_unbounded_tuple = len(type_args) == 2 and type_args[1] == ...
-        if is_unbounded_tuple:
-            return ArgAction.append
+    if annotation.is_variadic_tuple:
+        return ArgAction.append
 
     return ArgAction.set
 
 
 def infer_num_args(
     arg: Arg,
-    origin: typing.Any,
-    type_args: tuple[type, ...],
+    annotation: TypeView,
     action: ArgAction | Callable,
     long,
 ) -> int:
@@ -493,24 +466,21 @@ def infer_num_args(
     if isinstance(action, ArgAction) and action in no_extra_arg_actions:
         return 0
 
-    if is_union_type(origin):
+    if annotation.is_union:
         # Recursively determine the `num_args` value of each variant. Use the value
         # only if they all result in the same value.
         distinct_num_args = set()
         num_args_variants = []
-        for type_arg in type_args:
-            type_origin = typing.get_origin(type_arg)
-
+        for type_arg in annotation.inner_types:
             num_args = infer_num_args(
                 arg,
-                type_origin,
-                typing.get_args(type_arg),
+                type_arg,
                 action,
                 long,
             )
 
             distinct_num_args.add(num_args)
-            num_args_variants.append((type_arg, num_args))
+            num_args_variants.append((type_arg.raw, num_args))
 
         # The ideal case, where all union variants have the same arity and can be unioned amongst.
         if len(distinct_num_args) == 1:
@@ -527,27 +497,24 @@ def infer_num_args(
         )
 
     is_positional = not arg.short and not long
-    if is_subclass(origin, (list, set)) and is_positional:
+    if annotation.is_subclass_of((list, set)) and is_positional:
         return -1
 
-    is_tuple = is_subclass(origin, tuple)
-    is_unbounded_tuple = is_tuple and len(type_args) == 2 and type_args[1] == ...
+    if annotation.is_tuple and not annotation.is_variadic_tuple:
+        return len(annotation.args)
 
-    if is_tuple and not is_unbounded_tuple:
-        return len(type_args)
-
-    if is_unbounded_tuple and is_positional:
+    if annotation.is_variadic_tuple and is_positional:
         return -1
     return 1
 
 
-def infer_parse(arg: Arg, annotation: type) -> Callable:
+def infer_parse(arg: Arg, annotation: TypeView) -> Callable:
     if arg.parse:
-        if is_optional_type(annotation):
+        if annotation.is_optional:
             return parse_optional(arg.parse)
         return arg.parse
 
-    return parse_value(annotation, extra_annotations=arg.annotations)
+    return parse_value(annotation)
 
 
 def infer_help(arg: Arg, fallback_help: str | None) -> str | None:
@@ -645,3 +612,5 @@ no_extra_arg_actions = {
     ArgAction.version,
     ArgAction.help,
 }
+
+DEFAULT_ARG: Arg = Arg()

--- a/src/cappa/argparse.py
+++ b/src/cappa/argparse.py
@@ -5,15 +5,14 @@ import sys
 import typing
 from collections.abc import Callable
 
-from typing_extensions import assert_never
-
 from cappa.arg import Arg, ArgAction, no_extra_arg_actions
 from cappa.command import Command, Subcommand
 from cappa.help import generate_arg_groups
 from cappa.invoke import fulfill_deps
 from cappa.output import Exit, HelpExit, Output
 from cappa.parser import RawOption, Value
-from cappa.typing import assert_type, missing
+from cappa.type_view import Empty
+from cappa.typing import assert_never, assert_type
 
 if sys.version_info < (3, 9):  # pragma: no cover
     # Backport https://github.com/python/cpython/pull/3680
@@ -240,7 +239,7 @@ def add_argument(
     if not is_positional and arg.required:
         kwargs["required"] = arg.required
 
-    if arg.default is not missing:
+    if arg.default is not Empty:
         kwargs["default"] = argparse.SUPPRESS
 
     if num_args is not None and (arg.action and arg.action not in no_extra_arg_actions):

--- a/src/cappa/class_inspect.py
+++ b/src/cappa/class_inspect.py
@@ -6,17 +6,17 @@ import inspect
 import typing
 from enum import Enum
 
-from type_lens import CallableView, TypeView
 from typing_extensions import Self
 
-from cappa.typing import MISSING, find_annotations, missing, T
+from cappa.type_view import CallableView, Empty, EmptyType
+from cappa.typing import T, find_annotations
 
 if typing.TYPE_CHECKING:
     pass
 
 __all__ = [
-    "fields",
     "detect",
+    "fields",
 ]
 
 
@@ -28,8 +28,8 @@ def detect(cls: type) -> bool:
 class Field:
     name: str
     annotation: type
-    default: typing.Any | MISSING = missing
-    default_factory: typing.Any | MISSING = missing
+    default: typing.Any | EmptyType = Empty
+    default_factory: typing.Any | EmptyType = Empty
     metadata: dict = dataclasses.field(default_factory=dict)
 
 
@@ -42,10 +42,10 @@ class DataclassField(Field):
             field = cls(
                 name=f.name,
                 annotation=f.type,
-                default=f.default if f.default is not dataclasses.MISSING else missing,
+                default=f.default if f.default is not dataclasses.MISSING else Empty,
                 default_factory=f.default_factory
                 if f.default_factory is not dataclasses.MISSING
-                else missing,
+                else Empty,
                 metadata=f.metadata,
             )
             fields.append(field)
@@ -67,8 +67,8 @@ class AttrsField(Field):
             field = cls(
                 name=f.name,
                 annotation=f.type,
-                default=default or missing,
-                default_factory=default_factory or missing,
+                default=default or Empty,
+                default_factory=default_factory or Empty,
                 metadata=f.metadata,
             )
             fields.append(field)
@@ -83,11 +83,11 @@ class MsgspecField(Field):
 
         fields = []
         for f in msgspec.structs.fields(typ):
-            default = f.default if f.default is not msgspec.NODEFAULT else missing
+            default = f.default if f.default is not msgspec.NODEFAULT else Empty
             default_factory = (
                 f.default_factory
                 if f.default_factory is not msgspec.NODEFAULT
-                else missing
+                else Empty
             )
             field = cls(
                 name=f.name,
@@ -104,17 +104,19 @@ class PydanticV1Field(Field):
     @classmethod
     def collect(cls, typ) -> list[Self]:
         fields = []
-        type_hints = CallableView.from_callable(typ, include_extras=True)
-        for name, f in typ.__fields__.items():
-            annotation = TypeView(type_hints[name]).strip_optional().annotation
+        callable_view = CallableView.from_callable(typ, include_extras=True)
+        for param in callable_view.parameters:
+            name = param.name
+            f = typ.__fields__[name]
+            annotation = param.type_view.strip_optional().annotation
 
             field = cls(
                 name=name,
                 annotation=annotation,
                 default=f.default
                 if f.default.__repr__() != "PydanticUndefined"
-                else missing,
-                default_factory=f.default_factory or missing,
+                else Empty,
+                default_factory=f.default_factory or Empty,
             )
             fields.append(field)
         return fields
@@ -131,8 +133,8 @@ class PydanticV2Field(Field):
                 annotation=f.annotation,
                 default=f.default
                 if f.default.__repr__() != "PydanticUndefined"
-                else missing,
-                default_factory=f.default_factory or missing,
+                else Empty,
+                default_factory=f.default_factory or Empty,
             )
             fields.append(field)
         return fields
@@ -147,8 +149,8 @@ class PydanticV2DataclassField(Field):
             field = cls(
                 name=name,
                 annotation=f.annotation,
-                default=f.default or missing,
-                default_factory=f.default_factory or missing,
+                default=f.default or Empty,
+                default_factory=f.default_factory or Empty,
             )
             fields.append(field)
         return fields
@@ -234,15 +236,16 @@ def get_command_capable_object(obj):
             kwargs = dataclasses.asdict(self)
             return obj(**kwargs, **deps)
 
+        callable_view = CallableView.from_callable(obj, include_extras=True)
+
         # We need to create a fake signature for the above callable, which does
         # not retain the `Arg` annotations
-        sig = inspect.signature(obj)
-        sig_params: dict = dict(sig.parameters)
-        sig._parameters = sig_params  # type: ignore
-        call.__signature__ = sig  # type: ignore
+        signature = callable_view.signature
+        sig_params: dict = dict(signature.parameters)
+        signature._parameters = sig_params  # type: ignore
+        call.__signature__ = signature  # type: ignore
 
-        function_view = CallableView.from_callable(obj, include_extras=True)
-        for param_view in function_view.parameters:
+        for param_view in callable_view.parameters:
             if find_annotations(param_view.type_view, Dep):
                 continue
 

--- a/src/cappa/command.py
+++ b/src/cappa/command.py
@@ -5,6 +5,8 @@ import sys
 import typing
 from collections.abc import Callable
 
+from type_lens import CallableView
+
 from cappa import class_inspect
 from cappa.arg import Arg, ArgAction, Group
 from cappa.docstring import ClassHelpText
@@ -12,7 +14,7 @@ from cappa.env import Env
 from cappa.help import HelpFormatable, HelpFormatter, format_short_help
 from cappa.output import Exit, Output, prompt_types
 from cappa.subcommand import Subcommand
-from cappa.typing import get_type_hints, missing
+from cappa.typing import missing
 
 T = typing.TypeVar("T")
 
@@ -127,23 +129,26 @@ class Command(typing.Generic[T]):
             ]
         else:
             fields = class_inspect.fields(command.cmd_cls)
-            type_hints = get_type_hints(command.cmd_cls, include_extras=True)
+            function_view = CallableView.from_callable(
+                command.cmd_cls, include_extras=True
+            )
 
             arguments = []
 
-            for field in fields:
-                type_hint = type_hints[field.name]
-                arg_help = help_text.args.get(field.name)
+            for field, param_view in zip(fields, function_view.parameters):
+                arg_help = help_text.args.get(param_view.name)
 
                 maybe_subcommand = Subcommand.collect(
-                    field, type_hint, help_formatter=command.help_formatter
+                    field,
+                    param_view.type_view,
+                    help_formatter=command.help_formatter,
                 )
                 if maybe_subcommand:
                     arguments.append(maybe_subcommand)
                 else:
                     arg_defs: list[Arg] = Arg.collect(
                         field,
-                        type_hint,
+                        param_view.type_view,
                         fallback_help=arg_help,
                         default_short=command.default_short,
                         default_long=command.default_long,

--- a/src/cappa/command.py
+++ b/src/cappa/command.py
@@ -5,8 +5,6 @@ import sys
 import typing
 from collections.abc import Callable
 
-from type_lens import CallableView
-
 from cappa import class_inspect
 from cappa.arg import Arg, ArgAction, Group
 from cappa.docstring import ClassHelpText
@@ -14,7 +12,7 @@ from cappa.env import Env
 from cappa.help import HelpFormatable, HelpFormatter, format_short_help
 from cappa.output import Exit, Output, prompt_types
 from cappa.subcommand import Subcommand
-from cappa.typing import missing
+from cappa.type_view import CallableView, Empty
 
 T = typing.TypeVar("T")
 
@@ -201,7 +199,7 @@ class Command(typing.Generic[T]):
                 if is_subcommand:
                     continue
 
-                assert arg.default is not missing
+                assert arg.default is not Empty
                 value = arg.default
 
             else:

--- a/src/cappa/ext/docutils.py
+++ b/src/cappa/ext/docutils.py
@@ -4,14 +4,14 @@ import importlib
 import importlib.util
 import io
 import logging
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 
 from rich.console import Console
 
 import cappa
 from cappa.help import HelpFormatter, generate_arg_groups
 from cappa.output import Displayable, theme
-from cappa.typing import missing
+from cappa.type_view import Empty
 
 try:
     importlib.util.find_spec("docutils")
@@ -120,11 +120,13 @@ def render_to_docutils(command: cappa.Command, document):
                     for name in names:
                         option_content += nodes.literal(text=name)
                 else:
-                    name = arg.field_name
-                    name += f" {arg.value_name.upper()}"
+                    name = cast(str, arg.field_name)
+                    value_name = cast(str, arg.value_name)
+
+                    name += f" {value_name.upper()}"
                     option_content += nodes.literal(text=name)
 
-                if arg.default is not missing and arg.default is not None:
+                if arg.default is not Empty and arg.default is not None:
                     default = str(arg.default)
 
                     option_content += nodes.inline(text=" (")

--- a/src/cappa/help.py
+++ b/src/cappa/help.py
@@ -15,7 +15,7 @@ from typing_extensions import Self, TypeAlias
 from cappa.arg import Arg, ArgAction, Group, no_extra_arg_actions
 from cappa.output import Displayable
 from cappa.subcommand import Subcommand
-from cappa.typing import missing
+from cappa.type_view import Empty
 
 if typing.TYPE_CHECKING:
     from cappa.command import Command
@@ -43,7 +43,7 @@ def create_version_arg(version: str | Arg | None = None) -> Arg | None:
             group=(4, "Help"),
         )
 
-    if version.value_name is missing:
+    if version.value_name is Empty:
         raise ValueError(
             "Expected explicit version `Arg` to supply version number as its name, like `Arg('1.2.3', ...)`"
         )
@@ -157,7 +157,7 @@ def format_arg(help_formatter: HelpFormatter, arg: Arg) -> str:
     segments = []
     for format_segment in arg_format:
         default = ""
-        if arg.default is not None and arg.default is not missing:
+        if arg.default is not None and arg.default is not Empty:
             default = help_formatter.default_format.format(default=arg.default)
 
         choices = ""
@@ -229,7 +229,7 @@ def format_arg_name(arg: Arg | Subcommand, delimiter, *, n=0) -> str:
         text = f"[cappa.arg]{arg_names}[/cappa.arg]"
 
         if is_option and has_value:
-            name = arg.value_name.upper()
+            name = typing.cast(str, arg.value_name).upper()
             text = f"{text} [cappa.arg.name]{name}[/cappa.arg.name]"
 
         if not arg.required:

--- a/src/cappa/subcommand.py
+++ b/src/cappa/subcommand.py
@@ -3,19 +3,13 @@ from __future__ import annotations
 import dataclasses
 import typing
 
-from type_lens import TypeView
 from typing_extensions import Annotated, Self, TypeAlias
 
 from cappa.arg import Group
 from cappa.class_inspect import Field, extract_dataclass_metadata
 from cappa.completion.types import Completion
-from cappa.typing import (
-    MISSING,
-    T,
-    assert_type,
-    find_annotations,
-    missing,
-)
+from cappa.type_view import Empty, EmptyType, TypeView
+from cappa.typing import T, assert_type, find_annotations
 
 if typing.TYPE_CHECKING:
     from cappa.command import Command
@@ -35,12 +29,12 @@ class Subcommand:
         hidden: Whether the argument should be hidden in help text. Defaults to False.
     """
 
-    field_name: str | MISSING = ...
+    field_name: str | EmptyType = Empty
     required: bool | None = None
     group: str | tuple[int, str] | Group = (3, "Subcommands")
     hidden: bool = False
 
-    types: typing.Iterable[type] | MISSING = ...
+    types: typing.Iterable[type] | EmptyType = Empty
     options: dict[str, Command] = dataclasses.field(default_factory=dict)
 
     @classmethod
@@ -109,7 +103,7 @@ class Subcommand:
 
 
 def infer_types(arg: Subcommand, type_view: TypeView) -> typing.Iterable[type]:
-    if arg.types is not missing:
+    if arg.types is not Empty:
         return typing.cast(typing.Iterable[type], arg.types)
 
     if type_view.is_union:

--- a/src/cappa/type_view.py
+++ b/src/cappa/type_view.py
@@ -1,0 +1,15 @@
+from type_lens import CallableView, Empty, EmptyType, TypeView
+
+__all__ = [
+    "CallableView",
+    "Empty",
+    "EmptyType",
+    "TypeView",
+    "optional_repr_type",
+]
+
+
+def optional_repr_type(type_view: TypeView) -> str:
+    if type_view.annotation:
+        return type_view.repr_type
+    return "<empty>"

--- a/src/cappa/typing.py
+++ b/src/cappa/typing.py
@@ -4,7 +4,9 @@ import enum
 import typing
 from dataclasses import dataclass
 
-from type_lens import TypeView
+from typing_extensions import assert_never
+
+from cappa.type_view import TypeView
 
 try:
     from typing_extensions import Doc
@@ -17,10 +19,16 @@ except ImportError:  # pragma: no cover
         documentation: str
 
 
-T = typing.TypeVar("T")
+__all__ = [
+    "T",
+    "assert_never",
+    "assert_type",
+    "detect_choices",
+    "find_annotations",
+]
 
-missing = ...
-MISSING: typing.TypeAlias = type(missing)  # type: ignore
+
+T = typing.TypeVar("T")
 
 
 def find_annotations(type_view: TypeView, kind: type[T]) -> list[T]:
@@ -47,8 +55,6 @@ def detect_choices(type_view: TypeView) -> list[str] | None:
     if type_view.is_optional:
         type_view = type_view.strip_optional()
 
-    # origin = typing.get_origin(annotation) or annotation
-    # type_args = typing.get_args(annotation)
     if type_view.is_subclass_of(enum.Enum):
         return [v.value for v in type_view.annotation]
 
@@ -57,7 +63,6 @@ def detect_choices(type_view: TypeView) -> list[str] | None:
 
     if type_view.is_union:
         if all(t.is_literal for t in type_view.inner_types):
-            print(type_view.inner_types)
             return [str(t.args[0]) for t in type_view.inner_types]
 
     if type_view.is_literal:

--- a/src/cappa/typing.py
+++ b/src/cappa/typing.py
@@ -1,28 +1,21 @@
 from __future__ import annotations
 
 import enum
-import sys
-import types
 import typing
-from dataclasses import dataclass, field
-from inspect import cleandoc
+from dataclasses import dataclass
 
-import typing_extensions
-import typing_inspect
-from typing_extensions import Annotated, get_args, get_origin
-from typing_inspect import is_literal_type, is_optional_type
+from type_lens import TypeView
 
 try:
     from typing_extensions import Doc
 
-    doc_type: type | None = Doc
+    doc_type: type = Doc
 except ImportError:  # pragma: no cover
-    doc_type = None
 
-if sys.version_info < (3, 10):
-    NoneType = type(None)  # pragma: no cover
-else:
-    NoneType = types.NoneType  # type: ignore
+    @dataclass
+    class Doc:  # type: ignore
+        documentation: str
+
 
 T = typing.TypeVar("T")
 
@@ -30,50 +23,19 @@ missing = ...
 MISSING: typing.TypeAlias = type(missing)  # type: ignore
 
 
-@dataclass
-class ObjectAnnotation(typing.Generic[T]):
-    obj: list[T]
-    annotation: type
-    doc: str | None = None
-    other_annotations: list[type] = field(default_factory=list)
+def find_annotations(type_view: TypeView, kind: type[T]) -> list[T]:
+    if kind is None:
+        return []
 
+    result = []
+    for annotation in type_view.metadata:
+        if isinstance(annotation, kind):
+            result.append(annotation)
 
-def find_type_annotation(type_hint: type, kind: type[T]) -> ObjectAnnotation[T]:
-    instances = []
-    doc = None
+        if isinstance(annotation, type) and issubclass(annotation, kind):
+            result.append(annotation())
 
-    other_annotations = []
-    if get_origin(type_hint) is Annotated:
-        annotations = type_hint.__metadata__  # type: ignore
-        type_hint = type_hint.__origin__  # type: ignore
-
-        for annotation in annotations:
-            is_instance = isinstance(annotation, kind)
-            is_kind = isinstance(annotation, type) and issubclass(annotation, kind)
-
-            if is_instance or is_kind:
-                instance = annotation
-                if is_kind:
-                    instance = typing.cast(type, annotation)()
-
-                instances.append(instance)
-            else:
-                other_annotations.append(annotation)
-
-        if doc_type:
-            for annotation in annotations:
-                if isinstance(annotation, doc_type):
-                    doc = cleandoc(annotation.documentation)  # type: ignore
-                    break
-        else:
-            typing_extensions.assert_never(doc_type)  # type: ignore
-
-    return ObjectAnnotation(
-        obj=instances,
-        annotation=type_hint,
-        doc=doc,
-        other_annotations=other_annotations,
-    )
+    return result
 
 
 def assert_type(value: typing.Any, typ: type[T]) -> T:
@@ -81,224 +43,24 @@ def assert_type(value: typing.Any, typ: type[T]) -> T:
     return typing.cast(T, value)
 
 
-def backend_type(typ) -> str:
-    if is_literal_type(typ):
-        return get_args(typ)[0]
+def detect_choices(type_view: TypeView) -> list[str] | None:
+    if type_view.is_optional:
+        type_view = type_view.strip_optional()
 
-    return f"<{typ.__name__}>"
+    # origin = typing.get_origin(annotation) or annotation
+    # type_args = typing.get_args(annotation)
+    if type_view.is_subclass_of(enum.Enum):
+        return [v.value for v in type_view.annotation]
 
+    if type_view.is_subclass_of((tuple, list, set)):
+        type_view = type_view.inner_types[0]
 
-def is_union_type(typ):
-    if typing_inspect.is_union_type(typ):
-        return True
+    if type_view.is_union:
+        if all(t.is_literal for t in type_view.inner_types):
+            print(type_view.inner_types)
+            return [str(t.args[0]) for t in type_view.inner_types]
 
-    if hasattr(types, "UnionType") and typ is types.UnionType:
-        return True  # pragma: no cover
-    return False
-
-
-def is_none_type(typ):
-    return typ is NoneType
-
-
-def is_subclass(typ, superclass):
-    if not isinstance(typ, type):
-        return False
-
-    if typ is str:
-        return False
-
-    return issubclass(typ, superclass)
-
-
-def get_optional_type(typ: typing.Optional[T]):
-    if typ is NoneType:
-        return typ
-
-    args = get_args(typ)
-    if len(args) == 2:
-        return args[0]
-
-    return typing.Union[args]
-
-
-def get_type_hints(obj, include_extras=False):
-    result = _get_type_hints(obj, include_extras=include_extras)
-    if sys.version_info < (3, 11):  # pragma: no cover
-        result = fix_annotated_optional_type_hints(result)
-
-    return {k: v for k, v in result.items() if k not in {"return"}}
-
-
-def fix_annotated_optional_type_hints(
-    hints: dict[str, typing.Any],
-) -> dict[str, typing.Any]:  # pragma: no cover
-    """Normalize `Annotated` interacting with `get_type_hints` in versions <3.11.
-
-    https://github.com/python/cpython/issues/90353.
-    """
-    for param_name, hint in hints.items():
-        args = get_args(hint)
-        if (
-            get_origin(hint) is typing.Union
-            and get_origin(next(iter(args))) is Annotated
-        ):
-            hints[param_name] = next(iter(args))
-    return hints
-
-
-def is_of_type(annotation, types):
-    if typing_inspect.is_optional_type(annotation):
-        args = get_args(annotation)
-    else:
-        args = (annotation,)
-
-    for arg in args:
-        arg_annotation = get_origin(arg) or arg
-        if is_subclass(arg_annotation, types):
-            return True
-    return False
-
-
-def detect_choices(annotation: type) -> list[str] | None:
-    if is_optional_type(annotation):
-        annotation = get_optional_type(annotation)
-
-    origin = typing.get_origin(annotation) or annotation
-    type_args = typing.get_args(annotation)
-    if is_subclass(origin, enum.Enum):
-        return [v.value for v in origin]  # type: ignore
-
-    if is_subclass(origin, (tuple, list, set)):
-        origin = typing.cast(type, type_args[0])
-        type_args = typing.get_args(type_args[0])
-
-    if is_union_type(origin):
-        if all(is_literal_type(t) for t in type_args):
-            return [str(typing.get_args(t)[0]) for t in type_args]
-
-    if is_literal_type(origin):
-        return [str(t) for t in type_args]
+    if type_view.is_literal:
+        return [str(t) for t in type_view.args]
 
     return None
-
-
-def is_sequence_type(typ):
-    return is_subclass(get_origin(typ) or typ, (typing.List, typing.Tuple, typing.Set))
-
-
-def repr_type(t):
-    if isinstance(t, type) and not typing.get_origin(t):
-        return str(t.__name__)
-
-    return str(t).replace("typing.", "")
-
-
-if sys.version_info >= (3, 10):
-    _get_type_hints = typing.get_type_hints
-
-else:
-    from eval_type_backport import eval_type_backport
-
-    @typing.no_type_check
-    def _get_type_hints(
-        obj: typing.Any,
-        globalns: dict[str, typing.Any] | None = None,
-        localns: dict[str, typing.Any] | None = None,
-        include_extras: bool = False,
-    ) -> dict[str, typing.Any]:  # pragma: no cover
-        """Backport from python 3.10.8, with exceptions.
-
-        * Use `_forward_ref` instead of `typing.ForwardRef` to handle the `is_class` argument.
-        * `eval_type_backport` instead of `eval_type`, to backport syntax changes in Python 3.10.
-
-        https://github.com/python/cpython/blob/aaaf5174241496afca7ce4d4584570190ff972fe/Lib/typing.py#L1773-L1875
-        """
-        if getattr(obj, "__no_type_check__", None):
-            return {}
-        # Classes require a special treatment.
-        if isinstance(obj, type):
-            hints = {}
-            for base in reversed(obj.__mro__):
-                if globalns is None:
-                    base_globals = getattr(
-                        sys.modules.get(base.__module__, None), "__dict__", {}
-                    )
-                else:
-                    base_globals = globalns
-                ann = base.__dict__.get("__annotations__", {})
-                if isinstance(ann, types.GetSetDescriptorType):
-                    ann = {}
-                base_locals = dict(vars(base)) if localns is None else localns
-                if localns is None and globalns is None:
-                    # This is surprising, but required.  Before Python 3.10,
-                    # get_type_hints only evaluated the globalns of
-                    # a class.  To maintain backwards compatibility, we reverse
-                    # the globalns and localns order so that eval() looks into
-                    # *base_globals* first rather than *base_locals*.
-                    # This only affects ForwardRefs.
-                    base_globals, base_locals = base_locals, base_globals
-                for name, value in ann.items():
-                    if value is None:
-                        value = type(None)
-                    if isinstance(value, str):
-                        value = _forward_ref(value, is_argument=False, is_class=True)
-
-                    value = eval_type_backport(value, base_globals, base_locals)
-                    hints[name] = value
-            if not include_extras and hasattr(typing, "_strip_annotations"):
-                return {k: typing._strip_annotations(t) for k, t in hints.items()}
-            return hints
-
-        if globalns is None:
-            if isinstance(obj, types.ModuleType):
-                globalns = obj.__dict__
-            else:
-                nsobj = obj
-                # Find globalns for the unwrapped object.
-                while hasattr(nsobj, "__wrapped__"):
-                    nsobj = nsobj.__wrapped__
-                globalns = getattr(nsobj, "__globals__", {})
-            if localns is None:
-                localns = globalns
-        elif localns is None:
-            localns = globalns
-        hints = getattr(obj, "__annotations__", None)
-        if hints is None:
-            # Return empty annotations for something that _could_ have them.
-            if isinstance(obj, typing._allowed_types):
-                return {}
-
-            raise TypeError(f"{obj!r} is not a module, class, method, " "or function.")
-        defaults = typing._get_defaults(obj)
-        hints = dict(hints)
-        for name, value in hints.items():
-            if value is None:
-                value = type(None)
-            if isinstance(value, str):
-                # class-level forward refs were handled above, this must be either
-                # a module-level annotation or a function argument annotation
-
-                value = _forward_ref(
-                    value,
-                    is_argument=not isinstance(obj, types.ModuleType),
-                    is_class=False,
-                )
-            value = eval_type_backport(value, globalns, localns)
-            if name in defaults and defaults[name] is None:
-                value = typing.Optional[value]
-            hints[name] = value
-        return (
-            hints
-            if include_extras
-            else {k: typing._strip_annotations(t) for k, t in hints.items()}
-        )
-
-
-def _forward_ref(
-    arg: typing.Any,
-    is_argument: bool = True,
-    *,
-    is_class: bool = False,
-) -> typing.ForwardRef:
-    return typing.ForwardRef(arg, is_argument)

--- a/tests/arg/test_invalid_annotation_combination.py
+++ b/tests/arg/test_invalid_annotation_combination.py
@@ -36,7 +36,7 @@ def test_sequence_with_scalar_action(backend):
     with pytest.raises(ValueError) as e:
         parse(Args, "--help", backend=backend)
 
-    result = str(e.value).replace("typing.List", "list")
+    result = str(e.value).replace("List", "list")
     assert result == (
         "On field 'foo', apparent mismatch of annotated type with `Arg` options. "
         "'list[str]' type produces a sequence, whereas `num_args=1`/`action=ArgAction.set` do not. "
@@ -62,7 +62,7 @@ def test_sequence_with_scalar_num_args(backend):
     with pytest.raises(ValueError) as e:
         parse(ArgsBad, "--help", backend=backend)
 
-    result = str(e.value).replace("typing.List", "list")
+    result = str(e.value).replace("List", "list")
     assert result == (
         "On field 'foo', apparent mismatch of annotated type with `Arg` options. "
         "'list[str]' type produces a sequence, whereas `num_args=1`/`action=ArgAction.set` do not. "

--- a/tests/invoke/test_invalid_depdendency.py
+++ b/tests/invoke/test_invalid_depdendency.py
@@ -41,4 +41,4 @@ def test_unannotated_argument(backend):
     exc = e.value
     cause = exc.__cause__
     assert "due to resolution failure" in str(exc)
-    assert "`levels: <empty>` is not a valid dependency for Dep(command)." == str(cause)
+    assert "`levels: Any` is not a valid dependency for Dep(command)." == str(cause)

--- a/tests/test_manually_built.py
+++ b/tests/test_manually_built.py
@@ -20,7 +20,7 @@ command = cappa.Command(
     Foo,
     arguments=[
         cappa.Arg(field_name="bar", parse=str),
-        cappa.Arg(field_name="baz", parse=parse_list(int), num_args=-1),
+        cappa.Arg(field_name="baz", parse=parse_list(list[int]), num_args=-1),
     ],
     help="Short help.",
     description="Long description.",

--- a/tests/test_manually_built.py
+++ b/tests/test_manually_built.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import List
 
 import pytest
 
@@ -20,7 +21,7 @@ command = cappa.Command(
     Foo,
     arguments=[
         cappa.Arg(field_name="bar", parse=str),
-        cappa.Arg(field_name="baz", parse=parse_list(list[int]), num_args=-1),
+        cappa.Arg(field_name="baz", parse=parse_list(List[int]), num_args=-1),
     ],
     help="Short help.",
     description="Long description.",

--- a/uv.lock
+++ b/uv.lock
@@ -31,11 +31,9 @@ name = "cappa"
 version = "0.22.5"
 source = { editable = "." }
 dependencies = [
-    { name = "eval-type-backport", marker = "python_full_version < '3.10'" },
     { name = "rich" },
     { name = "type-lens" },
     { name = "typing-extensions" },
-    { name = "typing-inspect" },
 ]
 
 [package.optional-dependencies]
@@ -54,17 +52,14 @@ dev = [
     { name = "pytest" },
     { name = "ruff" },
     { name = "types-docutils" },
-    { name = "typing-extensions" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "docstring-parser", marker = "extra == 'docstring'", specifier = ">=0.15" },
-    { name = "eval-type-backport", marker = "python_full_version < '3.10'" },
     { name = "rich" },
-    { name = "type-lens", git = "https://github.com/dancardin/type-lens?branch=dc%2Fbackport-typing-syntax" },
+    { name = "type-lens", specifier = ">=0.2.2" },
     { name = "typing-extensions", specifier = ">=4.8.0" },
-    { name = "typing-inspect", specifier = ">=0.9.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -78,7 +73,6 @@ dev = [
     { name = "pytest", specifier = ">=8.1.1,<9" },
     { name = "ruff", specifier = ">=0.6.2" },
     { name = "types-docutils", specifier = ">=0.20.0" },
-    { name = "typing-extensions", specifier = ">=4.8.0" },
 ]
 
 [[package]]
@@ -533,10 +527,15 @@ wheels = [
 
 [[package]]
 name = "type-lens"
-version = "0.1.0a1"
-source = { git = "https://github.com/dancardin/type-lens?branch=dc%2Fbackport-typing-syntax#bfc1e4e99ee5967526001137403bcc2f9358f389" }
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "eval-type-backport", marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/23/e985fc964ee0c3e4648ca24e0bd600827ced58647c7cca60fe225221ba8c/type_lens-0.2.2.tar.gz", hash = "sha256:29c0b29e56de5b48c8bad6bd25ae964e2ef00d8985c286ed29d8c1df833a05e6", size = 361534 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/cd/c94200e5413e2cd3f0faba0ba764951a0a973aafa516d19fcfe263aebe86/type_lens-0.2.2-py3-none-any.whl", hash = "sha256:09d1af2a37ada0732b4568146fe78183fb131727bebaea08b761d445acd8de23", size = 14147 },
 ]
 
 [[package]]
@@ -555,17 +554,4 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
-]
-
-[[package]]
-name = "typing-inspect"
-version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mypy-extensions" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827 },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -28,11 +28,12 @@ wheels = [
 
 [[package]]
 name = "cappa"
-version = "0.22.4"
+version = "0.22.5"
 source = { editable = "." }
 dependencies = [
     { name = "eval-type-backport", marker = "python_full_version < '3.10'" },
     { name = "rich" },
+    { name = "type-lens" },
     { name = "typing-extensions" },
     { name = "typing-inspect" },
 ]
@@ -61,6 +62,7 @@ requires-dist = [
     { name = "docstring-parser", marker = "extra == 'docstring'", specifier = ">=0.15" },
     { name = "eval-type-backport", marker = "python_full_version < '3.10'" },
     { name = "rich" },
+    { name = "type-lens", git = "https://github.com/dancardin/type-lens?branch=dc%2Fbackport-typing-syntax" },
     { name = "typing-extensions", specifier = ">=4.8.0" },
     { name = "typing-inspect", specifier = ">=0.9.0" },
 ]
@@ -527,6 +529,14 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c0/3f/d7af728f075fb08564c5949a9c95e44352e23dee646869fa104a3b2060a3/tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f", size = 15164 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc", size = 12757 },
+]
+
+[[package]]
+name = "type-lens"
+version = "0.1.0a1"
+source = { git = "https://github.com/dancardin/type-lens?branch=dc%2Fbackport-typing-syntax#bfc1e4e99ee5967526001137403bcc2f9358f389" }
+dependencies = [
+    { name = "eval-type-backport", marker = "python_full_version < '3.10'" },
 ]
 
 [[package]]


### PR DESCRIPTION
~Not going to work in the short term. Some of the required functionality isn't merged yet, and none of it is in a released version.~

~Also, type-lens only supports python 3.9+, which is unfortunate. Although https://pypistats.org/packages/cappa maybe implies 3.8 is currently only installed when CI runs.~

~Also, all the variable names are currently "annotation", but probably ought to be `type_view`, so `annotation.annotation` doesn't look so stupid~

Externalize all the various little version-specific python typing handling and various typing related utilities into the `type-lens` package. Much of the type-lens API we use came from cappa's impls, but rebased on the much more comprehensive `TypeView` base provided by it.