### PR TITLE
feat: Improve union error messages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.20
 
+### 0.20.1
+
+- feat: Improve union error message.
+
 ### 0.20.0
 
 - feat: Implement exclusive argument groups.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cappa"
-version = "0.20.0"
+version = "0.20.1"
 description = "Declarative CLI argument parser."
 
 repository = "https://github.com/dancardin/cappa"

--- a/src/cappa/command.py
+++ b/src/cappa/command.py
@@ -227,7 +227,7 @@ class Command(typing.Generic[T]):
                 except Exception as e:
                     exception_reason = str(e)
                     raise Exit(
-                        f"Invalid value for '{arg.names_str()}' with value '{value}': {exception_reason}",
+                        f"Invalid value for '{arg.names_str()}': {exception_reason}",
                         code=2,
                         prog=prog,
                     )

--- a/tests/arg/test_file_io.py
+++ b/tests/arg/test_file_io.py
@@ -173,10 +173,8 @@ def test_invalid_mode(backend):
     with pytest.raises(cappa.Exit) as e:
         parse(Foo, "foo.py", backend=backend)
 
-    assert (
-        e.value.message
-        == "Invalid value for 'bar' with value 'foo.py': can't have text and binary mode at once"
-    )
+    assert str(e.value.message).startswith("Invalid value for 'bar'")
+    assert str(e.value.message).endswith("can't have text and binary mode at once")
 
 
 @backends

--- a/tests/arg/test_literal_intermixed_union.py
+++ b/tests/arg/test_literal_intermixed_union.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import textwrap
 from dataclasses import dataclass
 from typing import Literal, Union
 
@@ -33,7 +34,10 @@ def test_invalid_string(backend):
 
     assert e.value.code == 2
 
-    assert e.value.message == (
-        "Invalid value for 'name' with value 'thename': "
-        "Could not parse 'thename' given options: <int>, one"
+    err = textwrap.dedent(
+        """\
+        Invalid value for 'name': Possible variants
+         - Literal['one']: Invalid choice: 'thename' (choose from literal values 'one')
+         - int: invalid literal for int() with base 10: 'thename'"""
     )
+    assert err in str(e.value.message)

--- a/tests/arg/test_mapping_failure.py
+++ b/tests/arg/test_mapping_failure.py
@@ -23,7 +23,7 @@ def test_default(backend):
     assert e.value.code == 2
     assert (
         e.value.message
-        == "Invalid value for 'default' with value 'foo': invalid literal for int() with base 10: 'foo'"
+        == "Invalid value for 'default': invalid literal for int() with base 10: 'foo'"
     )
 
 

--- a/tests/arg/test_parse.py
+++ b/tests/arg/test_parse.py
@@ -74,5 +74,5 @@ def test_parse_optional(backend):
     assert e.value.code == 2
     assert (
         e.value.message
-        == "Invalid value for 'numbers' with value 'one': could not convert string to float: 'one'"
+        == "Invalid value for 'numbers': could not convert string to float: 'one'"
     )


### PR DESCRIPTION
As exemplified in the tests:
```
Invalid value for 'name': Possible variants
 - Literal['one']: Invalid choice: 'thename' (choose from literal values 'one')
 - int: invalid literal for int() with base 10: 'thename'
```
For some arbitrary bad value being routed through an option with some `Union[Literal['one'], int]` annotation.

Certainly one could get more specific and tailored error messages with custom parsers, as this is perhaps leaking python-isms out through the error messages, but this at least seems preferable to the original error: `Could not parse 'thename' given options: <int>, one`

Or worse, `set[Literal['one', 'two'] | None` was previously: `Could not parse '['three']' given options: <set>, <NoneType>`, but is now:
```
Invalid value for '-f': Possible variants
 - set[Literal['one', 'two']]: Invalid choice: 'three' (choose from literal values 'one', 'two')
 - <no value>
```