### PR TITLE
feat: Add `help_formatter` system wherein help text rendering can be customized.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.21
+
+### 0.21.0
+
+- feat: Add `help_formatter` system wherein help text rendering can be customized
+  to include or exclude things like default values, or choices. Notably changes
+  to include default values in help text by default.
+
 ## 0.20
 
 ### 0.20.1

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -39,7 +39,7 @@ Testing <testing>
 :hidden:
 
 Examples (vs click/typer/argparse) <examples>
-Help Text Inference <help>
+Help/Help Inference <help>
 Asyncio <asyncio>
 Manual Construction <manual_construction>
 Sphinx/Docutils Directive <sphinx>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cappa"
-version = "0.20.1"
+version = "0.21.0"
 description = "Declarative CLI argument parser."
 
 repository = "https://github.com/dancardin/cappa"

--- a/src/cappa/__init__.py
+++ b/src/cappa/__init__.py
@@ -3,6 +3,7 @@ from cappa.command import Command
 from cappa.completion.types import Completion
 from cappa.env import Env
 from cappa.file_io import FileMode
+from cappa.help import HelpFormatable, HelpFormatter
 from cappa.invoke import Dep
 from cappa.output import Exit, HelpExit, Output
 from cappa.subcommand import Subcommand, Subcommands
@@ -25,6 +26,8 @@ __all__ = [
     "FileMode",
     "Group",
     "HelpExit",
+    "HelpFormatable",
+    "HelpFormatter",
     "Output",
     "Subcommand",
     "Subcommands",

--- a/src/cappa/arg.py
+++ b/src/cappa/arg.py
@@ -223,7 +223,7 @@ class Arg(typing.Generic[T]):
         required = infer_required(self, annotation, default)
 
         parse = infer_parse(self, annotation)
-        help = infer_help(self, choices, fallback_help)
+        help = infer_help(self, fallback_help)
         completion = infer_completion(self, choices)
 
         group = infer_group(self, short, long, exclusive)
@@ -546,22 +546,12 @@ def infer_parse(arg: Arg, annotation: type) -> Callable:
     return parse_value(annotation, extra_annotations=arg.annotations)
 
 
-def infer_help(
-    arg: Arg, choices: list[str] | None, fallback_help: str | None
-) -> str | None:
+def infer_help(arg: Arg, fallback_help: str | None) -> str | None:
     help = arg.help
     if help is None:
         help = fallback_help
 
-    if not choices:
-        return help
-
-    choices_str = "Valid options: " + ", ".join(choices) + "."
-
-    if help:
-        return f"{help} {choices_str}"
-
-    return choices_str
+    return help
 
 
 def infer_completion(

--- a/src/cappa/argparse.py
+++ b/src/cappa/argparse.py
@@ -9,7 +9,7 @@ from typing_extensions import assert_never
 
 from cappa.arg import Arg, ArgAction, no_extra_arg_actions
 from cappa.command import Command, Subcommand
-from cappa.help import format_help, generate_arg_groups
+from cappa.help import generate_arg_groups
 from cappa.invoke import fullfill_deps
 from cappa.output import Exit, HelpExit, Output
 from cappa.parser import RawOption, Value
@@ -90,7 +90,7 @@ class ArgumentParser(argparse.ArgumentParser):
         raise Exit(message, code=status, prog=self.prog)
 
     def print_help(self):
-        raise HelpExit(format_help(self.command, self.prog))
+        raise HelpExit(self.command.help_formatter(self.command, self.prog))
 
 
 class BooleanOptionalAction(argparse.Action):

--- a/src/cappa/ext/docutils.py
+++ b/src/cappa/ext/docutils.py
@@ -9,7 +9,7 @@ from typing import Any, ClassVar
 from rich.console import Console
 
 import cappa
-from cappa.help import format_help, generate_arg_groups
+from cappa.help import HelpFormatter, generate_arg_groups
 from cappa.output import Displayable, theme
 from cappa.typing import missing
 
@@ -63,7 +63,7 @@ class CappaDirective(Directive):
 
 
 def render_to_terminal(command: cappa.Command, terminal_width: int):
-    raw_help: list[Displayable] = format_help(command, command.real_name())
+    raw_help: list[Displayable] = HelpFormatter.default(command, command.real_name())
 
     line_wrap = ""
     if terminal_width == 0:

--- a/src/cappa/parser.py
+++ b/src/cappa/parser.py
@@ -7,7 +7,7 @@ from collections import deque
 from cappa.arg import Arg, ArgAction, Group, no_extra_arg_actions
 from cappa.command import Command, Subcommand
 from cappa.completion.types import Completion, FileCompletion
-from cappa.help import format_help, format_subcommand_names
+from cappa.help import format_subcommand_names
 from cappa.invoke import fullfill_deps
 from cappa.output import Exit, HelpExit, Output
 from cappa.typing import T, assert_type
@@ -81,7 +81,9 @@ def backend(
             parse(context)
         except HelpAction as e:
             raise HelpExit(
-                format_help(e.command, e.command_name), code=0, prog=context.prog
+                e.command.help_formatter(e.command, e.command_name),
+                code=0,
+                prog=context.prog,
             )
         except VersionAction as e:
             raise Exit(e.version.value_name, code=0, prog=context.prog)

--- a/src/cappa/testing.py
+++ b/src/cappa/testing.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from typing_extensions import Unpack
 
 import cappa
+from cappa.help import HelpFormatable
 
 __all__ = [
     "CommandRunner",
@@ -17,15 +18,18 @@ class RunnerArgs(typing.TypedDict, total=False):
     """Available kwargs for `parse` and `invoke` function, to match `CommandRunner` fields."""
 
     obj: type
-    deps: typing.Sequence[typing.Callable] | typing.Mapping[
-        typing.Callable, cappa.Dep | typing.Any
-    ] | None
+    deps: (
+        typing.Sequence[typing.Callable]
+        | typing.Mapping[typing.Callable, cappa.Dep | typing.Any]
+        | None
+    )
     backend: typing.Callable | None
     output: cappa.Output | None
     color: bool
     version: str | cappa.Arg
     help: bool | cappa.Arg
     completion: bool | cappa.Arg
+    help_formatter: HelpFormatable
 
 
 @dataclass
@@ -72,15 +76,18 @@ class CommandRunner:
     """
 
     obj: type | None = None
-    deps: typing.Sequence[typing.Callable] | typing.Mapping[
-        typing.Callable, cappa.Dep | typing.Any
-    ] | None = None
+    deps: (
+        typing.Sequence[typing.Callable]
+        | typing.Mapping[typing.Callable, cappa.Dep | typing.Any]
+        | None
+    ) = None
     backend: typing.Callable | None = None
     output: cappa.Output | None = None
     color: bool = True
     version: str | cappa.Arg | None = None
     help: bool | cappa.Arg = True
     completion: bool | cappa.Arg = True
+    help_formatter: HelpFormatable | None = None
 
     base_args: list[str] = field(default_factory=lambda: [])
 
@@ -96,6 +103,9 @@ class CommandRunner:
             "completion": kwargs["completion"]
             if "completion" in kwargs
             else self.completion,
+            "help_formatter": kwargs["help_formatter"]
+            if "help_formatter" in kwargs
+            else self.help_formatter,
         }
 
     def parse(self, *args: str, **kwargs: Unpack[RunnerArgs]):

--- a/tests/arg/test_exclusive_group.py
+++ b/tests/arg/test_exclusive_group.py
@@ -59,8 +59,8 @@ def test_implicit_syntax_explicit_name(backend, capsys):
         textwrap.dedent(
             """
             Foo
-              [-v]
-              [--verbosity VERBOSE]
+              [-v]                       (Default: 0)
+              [--verbosity VERBOSE]      (Default: 0)
             """,
         ),
         "  ",

--- a/tests/help/test_help_formatter.py
+++ b/tests/help/test_help_formatter.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import textwrap
+from dataclasses import dataclass
+from typing import Literal
+
+import cappa
+import pytest
+from typing_extensions import Annotated
+
+from tests.utils import parse, strip_trailing_whitespace
+
+
+@dataclass
+class Args:
+    required: Annotated[str, cappa.Arg(help="I'm required")]
+    name: Annotated[str, cappa.Arg(help="I'm optional")] = "arg"
+    short: Annotated[str, cappa.Arg(short=True, help="I'm an option")] = "opt"
+    maybe: Annotated[str | None, cappa.Arg(short=True, help="maybe?")] = None
+
+
+def test_default_settings(capsys):
+    with pytest.raises(cappa.HelpExit) as e:
+        parse(Args, "--help", completion=False)
+
+    assert e.value.code == 0
+    out = strip_trailing_whitespace(capsys.readouterr().out)
+
+    assert out == textwrap.dedent(
+        """\
+        Usage: args [-s SHORT] [-m MAYBE] REQUIRED [NAME] [-h]
+
+          Options
+            [-s SHORT]    I'm an option (Default: opt)
+            [-m MAYBE]    maybe?
+
+          Arguments
+            REQUIRED      I'm required
+            [NAME]        I'm optional (Default: arg)
+
+          Help
+            [-h, --help]  Show this message and exit.
+        """
+    )
+
+
+def test_override_default_format(capsys):
+    with pytest.raises(cappa.HelpExit) as e:
+        parse(
+            Args,
+            "--help",
+            completion=False,
+            help_formatter=cappa.HelpFormatter.default.with_default_format(
+                "[Default '{default}']"
+            ),
+        )
+
+    assert e.value.code == 0
+    out = strip_trailing_whitespace(capsys.readouterr().out)
+
+    assert out == textwrap.dedent(
+        """\
+        Usage: args [-s SHORT] [-m MAYBE] REQUIRED [NAME] [-h]
+
+          Options
+            [-s SHORT]    I'm an option [Default 'opt']
+            [-m MAYBE]    maybe?
+
+          Arguments
+            REQUIRED      I'm required
+            [NAME]        I'm optional [Default 'arg']
+
+          Help
+            [-h, --help]  Show this message and exit.
+        """
+    )
+
+
+def test_override_help_format(capsys):
+    with pytest.raises(cappa.HelpExit) as e:
+        parse(
+            Args,
+            "--help",
+            completion=False,
+            help_formatter=cappa.HelpFormatter.default.with_arg_format(
+                ("{default}", "{help}")
+            ),
+        )
+
+    assert e.value.code == 0
+    out = strip_trailing_whitespace(capsys.readouterr().out)
+
+    assert out == textwrap.dedent(
+        """\
+        Usage: args [-s SHORT] [-m MAYBE] REQUIRED [NAME] [-h]
+
+          Options
+            [-s SHORT]    (Default: opt) I'm an option
+            [-m MAYBE]    maybe?
+
+          Arguments
+            REQUIRED      I'm required
+            [NAME]        (Default: arg) I'm optional
+
+          Help
+            [-h, --help]  Show this message and exit.
+        """
+    )
+
+
+def test_choice_options(capsys):
+    @dataclass
+    class Args:
+        required: Annotated[Literal["one", "two", "three"], cappa.Arg(help="Required.")]
+
+    with pytest.raises(cappa.HelpExit) as e:
+        parse(
+            Args,
+            "--help",
+            completion=False,
+        )
+
+    assert e.value.code == 0
+    out = strip_trailing_whitespace(capsys.readouterr().out)
+
+    assert out == textwrap.dedent(
+        """\
+        Usage: args REQUIRED [-h]
+
+          Arguments
+            REQUIRED      Required. Valid options: one, two, three.
+
+          Help
+            [-h, --help]  Show this message and exit.
+        """
+    )
+
+    with pytest.raises(cappa.HelpExit) as e:
+        parse(
+            Args,
+            "--help",
+            completion=False,
+            help_formatter=cappa.HelpFormatter().with_arg_format("{help}"),
+        )
+
+    assert e.value.code == 0
+    out = strip_trailing_whitespace(capsys.readouterr().out)
+
+    assert out == textwrap.dedent(
+        """\
+        Usage: args REQUIRED [-h]
+
+          Arguments
+            REQUIRED      Required.
+
+          Help
+            [-h, --help]  Show this message and exit.
+        """
+    )
+
+
+def test_callable_help_formatter(capsys):
+    @dataclass
+    class Args:
+        required: Annotated[int, cappa.Arg(help="Required.")]
+
+    def help_formatter(arg: cappa.Arg) -> str | None:
+        if arg.field_name == "required":
+            return f"Num args: {arg.num_args}"
+        return None
+
+    with pytest.raises(cappa.HelpExit) as e:
+        parse(
+            Args,
+            "--help",
+            completion=False,
+            help_formatter=cappa.HelpFormatter().with_arg_format(
+                ("{help}", help_formatter)
+            ),
+        )
+
+    assert e.value.code == 0
+    out = strip_trailing_whitespace(capsys.readouterr().out)
+
+    assert out == textwrap.dedent(
+        """\
+        Usage: args REQUIRED [-h]
+
+          Arguments
+            REQUIRED      Required. Num args: 1
+
+          Help
+            [-h, --help]  Show this message and exit.
+        """
+    )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,23 +5,27 @@ from unittest.mock import patch
 import pytest
 from cappa import argparse, parser
 from cappa.output import Exit
-from cappa.testing import CommandRunner
+from cappa.testing import CommandRunner, RunnerArgs
+from typing_extensions import Unpack
 
 backends = pytest.mark.parametrize("backend", [None, argparse.backend])
 
 runner = CommandRunner(base_args=[])
 
 
-def parse(cls, *args, **kwargs):
-    return runner.parse(*args, obj=cls, **kwargs)
+def parse(cls, *args: str, **kwargs: Unpack[RunnerArgs]):
+    kwargs["obj"] = cls
+    return runner.parse(*args, **kwargs)
 
 
-def invoke(cls, *args, **kwargs):
-    return runner.invoke(*args, obj=cls, **kwargs)
+def invoke(cls, *args: str, **kwargs: Unpack[RunnerArgs]):
+    kwargs["obj"] = cls
+    return runner.invoke(*args, **kwargs)
 
 
-def invoke_async(cls, *args, **kwargs):
-    return runner.invoke_async(*args, obj=cls, **kwargs)
+def invoke_async(cls, *args: str, **kwargs: Unpack[RunnerArgs]):
+    kwargs["obj"] = cls
+    return runner.invoke_async(*args, **kwargs)
 
 
 def parse_completion(cls, *args, location=None) -> Union[str, None]:


### PR DESCRIPTION
This enables one to include or exclude things like default values, or choices. Notably changes to include default values in help text by default.

Fixes https://github.com/DanCardin/cappa/issues/125

---

A kitchen-sink style example of most of the available options, used together.

```python
from cappa import parse, HelpFormatter, Arg

class Command:
    foo: Annotated[str, Arg(help="Help text.", deprecated=True)] = "foo"

def deprecated(arg: Arg) -> str | None:
    if arg.deprecated:
        return "Deprecrated"
    return None

parse(Command, help_formatter=HelpFormatter(arg_format=("{default}", "{help}", deprecated), default_format="(Default `{default}`)")
```

Resulting in something like `(Default `foo`) Help text. Deprecrated`.