### PR TITLE
fix: action inference when `default` is an `Env`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.21
 
+### 0.21.2
+- fix: action inference when `default` is an `Env`.
+
 ### 0.21.1
 
 - feat: Update automatic inference to support `date`, `time`, and `datetime` parsing (for isoformat).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cappa"
-version = "0.21.1"
+version = "0.21.2"
 description = "Declarative CLI argument parser."
 
 repository = "https://github.com/dancardin/cappa"

--- a/src/cappa/arg.py
+++ b/src/cappa/arg.py
@@ -445,6 +445,9 @@ def infer_action(
 
     # Coerce raw `bool` into flags by default
     if is_subclass(origin, bool):
+        if isinstance(default, Env):
+            default = default.default
+
         if default is not missing and bool(default):
             return ArgAction.store_false
 

--- a/src/cappa/argparse.py
+++ b/src/cappa/argparse.py
@@ -10,7 +10,7 @@ from typing_extensions import assert_never
 from cappa.arg import Arg, ArgAction, no_extra_arg_actions
 from cappa.command import Command, Subcommand
 from cappa.help import generate_arg_groups
-from cappa.invoke import fullfill_deps
+from cappa.invoke import fulfill_deps
 from cappa.output import Exit, HelpExit, Output
 from cappa.parser import RawOption, Value
 from cappa.typing import assert_type, missing
@@ -129,7 +129,7 @@ def custom_action(arg: Arg, action: Callable):
             if option_string:
                 fullfilled_deps[RawOption] = RawOption.from_str(option_string)
 
-            deps = fullfill_deps(action, fullfilled_deps)
+            deps = fulfill_deps(action, fullfilled_deps)
             result = action(**deps)
             setattr(namespace, self.dest, result)
 

--- a/src/cappa/parser.py
+++ b/src/cappa/parser.py
@@ -8,7 +8,7 @@ from cappa.arg import Arg, ArgAction, Group, no_extra_arg_actions
 from cappa.command import Command, Subcommand
 from cappa.completion.types import Completion, FileCompletion
 from cappa.help import format_subcommand_names
-from cappa.invoke import fullfill_deps
+from cappa.invoke import fulfill_deps
 from cappa.output import Exit, HelpExit, Output
 from cappa.typing import T, assert_type
 
@@ -579,7 +579,7 @@ def consume_arg(
     else:
         action_handler = action
 
-    fullfilled_deps: dict = {
+    fulfilled_deps: dict = {
         Command: context.command,
         Output: context.output,
         ParseContext: context,
@@ -587,9 +587,9 @@ def consume_arg(
         Value: Value(result),
     }
     if option:
-        fullfilled_deps[RawOption] = option
+        fulfilled_deps[RawOption] = option
 
-    kwargs = fullfill_deps(action_handler, fullfilled_deps)
+    kwargs = fulfill_deps(action_handler, fulfilled_deps)
     context.result[arg.field_name] = action_handler(**kwargs)
 
     check_deprecated(context, arg, option)


### PR DESCRIPTION
Namely `ex: Annotated[bool, cappa.Arg(long=True, default=cappa.Env("EX"))] = False` was inferring `store_false`, when it ought to have been inferring `store_true`.