### PR TITLE
fix: Avoid applying annotated type parsing to default value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 0.22
 
+### 0.22.4
+
+- fix: Avoid applying annotated type parsing to default value.
+
+### 0.22.3
+
+- fix: Ensure compatibility with python 3.13
+
 ### 0.22.2
 
 - fix: Ensure `Arg.choices` is inferred when `T | None` where `T` would have inferred `choices` is encountered.
@@ -17,6 +25,7 @@
 ## 0.21
 
 ### 0.21.2
+
 - fix: action inference when `default` is an `Env`.
 
 ### 0.21.1
@@ -60,7 +69,7 @@
 ## 0.18.1
 
 - feat: Add `deprecated` option, allowing deprecation of args, options, and subcommands
->>>>>>> 142825c (feat: Implement exclusive groups.)
+  > > > > > > > 142825c (feat: Implement exclusive groups.)
 
 ### 0.18.0
 

--- a/docs/source/arg.md
+++ b/docs/source/arg.md
@@ -183,6 +183,19 @@ dataclasses).
 However it can be convenient to use cappa's default because it does not affect
 the optionality of the field in question in the resultant class constructor.
 
+```{note}
+The `default` value is not parsed by `parse`. That is to say, if no value is
+selected at the CLI and the default value is used instead, it will not be
+coerced into the annotated type automatically.
+
+The reason for this is twofold:
+
+1. Typechecking should already emit an error when the given default is of the incorrect type.
+2. This interacts poorly with types who's constructor does not accept an instance
+   of the given type as an input argument. For example, `foo: Foo = Foo('')`
+   would infer `parse=Foo` and attempt to pass `Foo(Foo(''))` during parsing.
+```
+
 ### Environment Variable Fallback
 
 You can also use the default field to supply supported kinds of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cappa"
-version = "0.22.3"
+version = "0.22.4"
 description = "Declarative CLI argument parser."
 
 repository = "https://github.com/dancardin/cappa"

--- a/src/cappa/arg.py
+++ b/src/cappa/arg.py
@@ -94,6 +94,8 @@ class Arg(typing.Generic[T]):
             arguments.
         default: An explicit default CLI value. When left unspecified, the default is
             inferred from the class' default or the adapter default/default_factory.
+            Note, if the default value is used, it will not be coerced into the annotated
+            type through the `parse` method.
         help: By default, the help text will be inferred from the containing class'
             arguments' section, if it exists. Alternatively, you can directly supply
             the help text here.

--- a/src/cappa/env.py
+++ b/src/cappa/env.py
@@ -24,7 +24,7 @@ class Env:
         self.env_vars = (env_var, *env_vars)
         self.default = default
 
-    def evaluate(self) -> str | None:
+    def __call__(self) -> str | None:
         for env_var in self.env_vars:
             value = os.getenv(env_var)
             if value:

--- a/tests/arg/test_default.py
+++ b/tests/arg/test_default.py
@@ -18,3 +18,16 @@ class Command:
 def test_valid(backend):
     test = parse(Command, "1", "2", backend=backend)
     assert test == Command(1, 2)
+
+
+@backends
+def test_default_is_not_mapped(backend):
+    @dataclass
+    class Command:
+        foo: int = "4"  # type: ignore
+
+    test = parse(Command, "1", backend=backend)
+    assert test == Command(1)
+
+    test = parse(Command, backend=backend)
+    assert test == Command("4")  # type: ignore


### PR DESCRIPTION
I can't really see why this would be undesirable behavior in the general case.

Technically **today**, you might supply `Annotated[int, Arg(default='')]` which wont fail to typecheck, and will now be the incorrect type. But there is active discussion about a PEP to enable the Annotated type to tie back to the Arg instance, which would address this. Plus, the Arg default is very much less desireable to use than the native python/dataclass one for exactly that reason.

When using native defaults, it should typecheck correctly, and this way **enables** one to use the correct type there, where they might have previously been **forced** to use the less desirable one.

Fixes issue discovered in https://github.com/DanCardin/cappa/discussions/137