### PR TITLE
 feat: Support native inference parser for dataclass-like annotations. 

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.9"
+    python: "3.10"
 
 python:
   install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.24
+
+### 0.24.0
+- feat: Support native inference parser for dataclass-like annotation
+s.
+  Note this contains a minor breaking changes:
+
+  * The `Arg.annotations` attribute was swapped for `Arg.type_view`. This was
+    never a documented feature, but rather a side-effect required to implement
+    certain built-in parser inferences. Swapping to `type_view` exposes strictly
+    more information, and in a nicer interface.
+
+- feat: User defined parsers can access the `TypeView` by accepting it as an argument.
+
+## 0.23
+
+### 0.23.0
+- fix: Avoid storing has_value=False values in the parser.
+- feat: Introduce `Arg.destructure()` and `Arg.has_value`.
+- chore: Swap custom MISSING/missing for EmptyType/Empty.
+- refactor: Adopt the type-lens package.
+
 ## 0.22
 
 ### 0.22.5

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -5,12 +5,12 @@ description = ""
 authors = [
   {name = "Dan Cardin", email = "ddcardin@gmail.com"},
 ]
-requires-python = ">=3.9,<4"
+requires-python = ">=3.10,<4"
 
 dependencies = [
     "furo >= 2022.4.7",
     "linkify-it-py",
-    "myst-parser[linkify] >=2",
+    "myst-parser[linkify] >=4",
     "sphinx ~= 7.1.0",
     "sphinx-autoapi ~= 3.0.0",
     "sphinx-autobuild",

--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -2,7 +2,7 @@
 
 ```{eval-rst}
 .. autoapimodule:: cappa
-   :members: parse, invoke, invoke_async, collect, command, Command, Subcommand, Dep, Arg, ArgAction, Exit, Env, Completion, Output, FileMode
+   :members: parse, invoke, invoke_async, collect, command, Command, Subcommand, Dep, Arg, ArgAction, Exit, Env, Completion, Output, FileMode, unpack_arguments
 ```
 
 ```{eval-rst}

--- a/docs/source/backends.md
+++ b/docs/source/backends.md
@@ -2,7 +2,7 @@
 
 ```{note}
 If you're looking for custom parsing of individual arguments, you probably want
-[Arg.parse](./arg.md#parse) or [Arg.action](./arg.md#action).
+[Arg.parse](./arg.md#arg-parse) or [Arg.action](./arg.md#arg-action).
 
 This document is concerned with the actual e2e CLI parsing process.
 ```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,7 @@ html_theme_options = {
 }
 html_static_path = ["_static"]
 
-myst_heading_anchors = 3
+myst_heading_anchors = 4
 myst_enable_extensions = [
     "amsmath",
     "colon_fence",

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-requires-python = ">=3.9, <4"
+requires-python = ">=3.10, <4"
 resolution-markers = [
     "python_full_version < '3.12'",
     "python_full_version >= '3.12'",
@@ -131,21 +131,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/ae/ce2c12fcac59cb3860b2e2d76dc405253a4475436b1861d95fe75bdea520/charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4", size = 142167 },
     { url = "https://files.pythonhosted.org/packages/ed/3a/a448bf035dce5da359daf9ae8a16b8a39623cc395a2ffb1620aa1bce62b0/charset_normalizer-3.3.2-cp312-cp312-win32.whl", hash = "sha256:d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7", size = 93041 },
     { url = "https://files.pythonhosted.org/packages/b6/7c/8debebb4f90174074b827c63242c23851bdf00a532489fba57fef3416e40/charset_normalizer-3.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001", size = 100397 },
-    { url = "https://files.pythonhosted.org/packages/f7/9d/bcf4a449a438ed6f19790eee543a86a740c77508fbc5ddab210ab3ba3a9a/charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4", size = 194198 },
-    { url = "https://files.pythonhosted.org/packages/66/fe/c7d3da40a66a6bf2920cce0f436fa1f62ee28aaf92f412f0bf3b84c8ad6c/charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d", size = 122494 },
-    { url = "https://files.pythonhosted.org/packages/2a/9d/a6d15bd1e3e2914af5955c8eb15f4071997e7078419328fee93dfd497eb7/charset_normalizer-3.3.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0", size = 120393 },
-    { url = "https://files.pythonhosted.org/packages/3d/85/5b7416b349609d20611a64718bed383b9251b5a601044550f0c8983b8900/charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269", size = 138331 },
-    { url = "https://files.pythonhosted.org/packages/79/66/8946baa705c588521afe10b2d7967300e49380ded089a62d38537264aece/charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c", size = 148097 },
-    { url = "https://files.pythonhosted.org/packages/44/80/b339237b4ce635b4af1c73742459eee5f97201bd92b2371c53e11958392e/charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519", size = 140711 },
-    { url = "https://files.pythonhosted.org/packages/98/69/5d8751b4b670d623aa7a47bef061d69c279e9f922f6705147983aa76c3ce/charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796", size = 142251 },
-    { url = "https://files.pythonhosted.org/packages/1f/8d/33c860a7032da5b93382cbe2873261f81467e7b37f4ed91e25fed62fd49b/charset_normalizer-3.3.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185", size = 144636 },
-    { url = "https://files.pythonhosted.org/packages/c2/65/52aaf47b3dd616c11a19b1052ce7fa6321250a7a0b975f48d8c366733b9f/charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c", size = 139514 },
-    { url = "https://files.pythonhosted.org/packages/51/fd/0ee5b1c2860bb3c60236d05b6e4ac240cf702b67471138571dad91bcfed8/charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458", size = 145528 },
-    { url = "https://files.pythonhosted.org/packages/e1/9c/60729bf15dc82e3aaf5f71e81686e42e50715a1399770bcde1a9e43d09db/charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2", size = 149804 },
-    { url = "https://files.pythonhosted.org/packages/53/cd/aa4b8a4d82eeceb872f83237b2d27e43e637cac9ffaef19a1321c3bafb67/charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8", size = 141708 },
-    { url = "https://files.pythonhosted.org/packages/54/7f/cad0b328759630814fcf9d804bfabaf47776816ad4ef2e9938b7e1123d04/charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561", size = 142708 },
-    { url = "https://files.pythonhosted.org/packages/c1/9d/254a2f1bcb0ce9acad838e94ed05ba71a7cb1e27affaa4d9e1ca3958cdb6/charset_normalizer-3.3.2-cp39-cp39-win32.whl", hash = "sha256:aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f", size = 92830 },
-    { url = "https://files.pythonhosted.org/packages/2f/0e/d7303ccae9735ff8ff01e36705ad6233ad2002962e8668a970fc000c5e1b/charset_normalizer-3.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d", size = 100376 },
     { url = "https://files.pythonhosted.org/packages/28/76/e6222113b83e3622caa4bb41032d0b1bf785250607392e1b778aca0b8a7d/charset_normalizer-3.3.2-py3-none-any.whl", hash = "sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc", size = 48543 },
 ]
 
@@ -191,7 +176,7 @@ dependencies = [
 requires-dist = [
     { name = "furo", specifier = ">=2022.4.7" },
     { name = "linkify-it-py" },
-    { name = "myst-parser", extras = ["linkify"], specifier = ">=2" },
+    { name = "myst-parser", extras = ["linkify"], specifier = ">=4" },
     { name = "sphinx", specifier = "~=7.1.0" },
     { name = "sphinx-autoapi", specifier = "~=3.0.0" },
     { name = "sphinx-autobuild" },
@@ -288,18 +273,6 @@ wheels = [
 ]
 
 [[package]]
-name = "importlib-metadata"
-version = "8.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/bd/fa8ce65b0a7d4b6d143ec23b0f5fd3f7ab80121078c465bc02baeaab22dc/importlib_metadata-8.4.0.tar.gz", hash = "sha256:9a547d3bc3608b025f93d403fdd1aae741c24fbb8314df4b155675742ce303c5", size = 54320 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/14/362d31bf1076b21e1bcdcb0dc61944822ff263937b804a79231df2774d28/importlib_metadata-8.4.0-py3-none-any.whl", hash = "sha256:66f342cc6ac9818fc6ff340576acd24d65ba0b3efabb2b4ac08b598965a4a2f1", size = 26269 },
-]
-
-[[package]]
 name = "jinja2"
 version = "3.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -371,16 +344,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/07/2dc76aa51b481eb96a4c3198894f38b480490e834479611a4053fbf08623/MarkupSafe-2.1.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:58c98fee265677f63a4385256a6d7683ab1832f3ddd1e66fe948d5880c21a169", size = 33038 },
     { url = "https://files.pythonhosted.org/packages/96/0c/620c1fb3661858c0e37eb3cbffd8c6f732a67cd97296f725789679801b31/MarkupSafe-2.1.5-cp312-cp312-win32.whl", hash = "sha256:8590b4ae07a35970728874632fed7bd57b26b0102df2d2b233b6d9d82f6c62ad", size = 16572 },
     { url = "https://files.pythonhosted.org/packages/3f/14/c3554d512d5f9100a95e737502f4a2323a1959f6d0d01e0d0997b35f7b10/MarkupSafe-2.1.5-cp312-cp312-win_amd64.whl", hash = "sha256:823b65d8706e32ad2df51ed89496147a42a2a6e01c13cfb6ffb8b1e92bc910bb", size = 17127 },
-    { url = "https://files.pythonhosted.org/packages/0f/31/780bb297db036ba7b7bbede5e1d7f1e14d704ad4beb3ce53fb495d22bc62/MarkupSafe-2.1.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7a68b554d356a91cce1236aa7682dc01df0edba8d043fd1ce607c49dd3c1edcf", size = 18193 },
-    { url = "https://files.pythonhosted.org/packages/6c/77/d77701bbef72892affe060cdacb7a2ed7fd68dae3b477a8642f15ad3b132/MarkupSafe-2.1.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:db0b55e0f3cc0be60c1f19efdde9a637c32740486004f20d1cff53c3c0ece4d2", size = 14073 },
-    { url = "https://files.pythonhosted.org/packages/d9/a7/1e558b4f78454c8a3a0199292d96159eb4d091f983bc35ef258314fe7269/MarkupSafe-2.1.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e53af139f8579a6d5f7b76549125f0d94d7e630761a2111bc431fd820e163b8", size = 26486 },
-    { url = "https://files.pythonhosted.org/packages/5f/5a/360da85076688755ea0cceb92472923086993e86b5613bbae9fbc14136b0/MarkupSafe-2.1.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17b950fccb810b3293638215058e432159d2b71005c74371d784862b7e4683f3", size = 25685 },
-    { url = "https://files.pythonhosted.org/packages/6a/18/ae5a258e3401f9b8312f92b028c54d7026a97ec3ab20bfaddbdfa7d8cce8/MarkupSafe-2.1.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c31f53cdae6ecfa91a77820e8b151dba54ab528ba65dfd235c80b086d68a465", size = 25338 },
-    { url = "https://files.pythonhosted.org/packages/0b/cc/48206bd61c5b9d0129f4d75243b156929b04c94c09041321456fd06a876d/MarkupSafe-2.1.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:bff1b4290a66b490a2f4719358c0cdcd9bafb6b8f061e45c7a2460866bf50c2e", size = 30439 },
-    { url = "https://files.pythonhosted.org/packages/d1/06/a41c112ab9ffdeeb5f77bc3e331fdadf97fa65e52e44ba31880f4e7f983c/MarkupSafe-2.1.5-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:bc1667f8b83f48511b94671e0e441401371dfd0f0a795c7daa4a3cd1dde55bea", size = 29531 },
-    { url = "https://files.pythonhosted.org/packages/02/8c/ab9a463301a50dab04d5472e998acbd4080597abc048166ded5c7aa768c8/MarkupSafe-2.1.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5049256f536511ee3f7e1b3f87d1d1209d327e818e6ae1365e8653d7e3abb6a6", size = 29823 },
-    { url = "https://files.pythonhosted.org/packages/bc/29/9bc18da763496b055d8e98ce476c8e718dcfd78157e17f555ce6dd7d0895/MarkupSafe-2.1.5-cp39-cp39-win32.whl", hash = "sha256:00e046b6dd71aa03a41079792f8473dc494d564611a8f89bbbd7cb93295ebdcf", size = 16658 },
-    { url = "https://files.pythonhosted.org/packages/f6/f8/4da07de16f10551ca1f640c92b5f316f9394088b183c6a57183df6de5ae4/MarkupSafe-2.1.5-cp39-cp39-win_amd64.whl", hash = "sha256:fa173ec60341d6bb97a89f5ea19c85c5643c1e7dedebc22f5181eb73573142c5", size = 17211 },
 ]
 
 [[package]]
@@ -406,7 +369,7 @@ wheels = [
 
 [[package]]
 name = "myst-parser"
-version = "3.0.1"
+version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils" },
@@ -416,9 +379,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "sphinx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/64/e2f13dac02f599980798c01156393b781aec983b52a6e4057ee58f07c43a/myst_parser-3.0.1.tar.gz", hash = "sha256:88f0cb406cb363b077d176b51c476f62d60604d68a8dcdf4832e080441301a87", size = 92392 }
+sdist = { url = "https://files.pythonhosted.org/packages/85/55/6d1741a1780e5e65038b74bce6689da15f620261c490c3511eb4c12bac4b/myst_parser-4.0.0.tar.gz", hash = "sha256:851c9dfb44e36e56d15d05e72f02b80da21a9e0d07cba96baf5e2d476bb91531", size = 93858 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/de/21aa8394f16add8f7427f0a1326ccd2b3a2a8a3245c9252bc5ac034c6155/myst_parser-3.0.1-py3-none-any.whl", hash = "sha256:6457aaa33a5d474aca678b8ead9b3dc298e89c68e67012e73146ea6fd54babf1", size = 83163 },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/b036f8fdb667587bb37df29dc6644681dd78b7a2a6321a34684b79412b28/myst_parser-4.0.0-py3-none-any.whl", hash = "sha256:b9317997552424448c6096c2558872fdb6f81d3ecb3a40ce84a7518798f3f28d", size = 84563 },
 ]
 
 [package.optional-dependencies]
@@ -495,15 +458,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597 },
     { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527 },
     { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446 },
-    { url = "https://files.pythonhosted.org/packages/65/d8/b7a1db13636d7fb7d4ff431593c510c8b8fca920ade06ca8ef20015493c5/PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d", size = 184777 },
-    { url = "https://files.pythonhosted.org/packages/0a/02/6ec546cd45143fdf9840b2c6be8d875116a64076218b61d68e12548e5839/PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f", size = 172318 },
-    { url = "https://files.pythonhosted.org/packages/0e/9a/8cc68be846c972bda34f6c2a93abb644fb2476f4dcc924d52175786932c9/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290", size = 720891 },
-    { url = "https://files.pythonhosted.org/packages/e9/6c/6e1b7f40181bc4805e2e07f4abc10a88ce4648e7e95ff1abe4ae4014a9b2/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12", size = 722614 },
-    { url = "https://files.pythonhosted.org/packages/3d/32/e7bd8535d22ea2874cef6a81021ba019474ace0d13a4819c2a4bce79bd6a/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19", size = 737360 },
-    { url = "https://files.pythonhosted.org/packages/d7/12/7322c1e30b9be969670b672573d45479edef72c9a0deac3bb2868f5d7469/PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e", size = 699006 },
-    { url = "https://files.pythonhosted.org/packages/82/72/04fcad41ca56491995076630c3ec1e834be241664c0c09a64c9a2589b507/PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725", size = 723577 },
-    { url = "https://files.pythonhosted.org/packages/ed/5e/46168b1f2757f1fcd442bc3029cd8767d88a98c9c05770d8b420948743bb/PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631", size = 144593 },
-    { url = "https://files.pythonhosted.org/packages/19/87/5124b1c1f2412bb95c59ec481eaf936cd32f0fe2a7b16b97b81c4c017a6a/PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8", size = 162312 },
 ]
 
 [[package]]
@@ -567,7 +521,6 @@ dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "docutils" },
     { name = "imagesize" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
     { name = "jinja2" },
     { name = "packaging" },
     { name = "pygments" },
@@ -742,7 +695,6 @@ version = "0.38.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/43/e2/d49a94ecb665b3a1c34b40c78165a737abc384fcabc843ccb14a3bd3dc37/starlette-0.38.2.tar.gz", hash = "sha256:c7c0441065252160993a1a37cf2a73bb64d271b17303e0b0c1eb7191cfb12d75", size = 2844770 }
 wheels = [
@@ -858,26 +810,10 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/d9/120d212d2952342e2c9673096f5c17cd48e90a7c9ff203ab1ad2f974befe/watchfiles-0.23.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:9f8e6bb5ac007d4a4027b25f09827ed78cbbd5b9700fd6c54429278dacce05d1", size = 596603 },
     { url = "https://files.pythonhosted.org/packages/3b/25/ec3676b140a93ac256d058a6f82810cf5e0e42fd444b948c62bc56f57f52/watchfiles-0.23.0-cp313-none-win32.whl", hash = "sha256:f46c6f0aec8d02a52d97a583782d9af38c19a29900747eb048af358a9c1d8e5b", size = 263898 },
     { url = "https://files.pythonhosted.org/packages/1a/c6/bf3b8cbe6944499fbe0d400175560a200cdecadccbacc8ace74486565d74/watchfiles-0.23.0-cp313-none-win_amd64.whl", hash = "sha256:f449afbb971df5c6faeb0a27bca0427d7b600dd8f4a068492faec18023f0dcff", size = 275220 },
-    { url = "https://files.pythonhosted.org/packages/b4/dd/8214a88b94fd0ed559e3f38b973a01bb3b48e9365dcb1d1966438dce816d/watchfiles-0.23.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:a753993635eccf1ecb185dedcc69d220dab41804272f45e4aef0a67e790c3eb3", size = 375565 },
-    { url = "https://files.pythonhosted.org/packages/67/38/6a24bf5724ce3d6e9087a7f9b7faf33760dfa5616974eda1ed35ba9ef41b/watchfiles-0.23.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6bb91fa4d0b392f0f7e27c40981e46dda9eb0fbc84162c7fb478fe115944f491", size = 370564 },
-    { url = "https://files.pythonhosted.org/packages/b1/32/86f0d012d344168ed30746c04cac7ce3292ef5220fa4823ad73ca5f1f1db/watchfiles-0.23.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b1f67312efa3902a8e8496bfa9824d3bec096ff83c4669ea555c6bdd213aa516", size = 442747 },
-    { url = "https://files.pythonhosted.org/packages/29/46/f41defd581154c4022c04ef41f812e6fd1633e75444e7b12147fdb0b7364/watchfiles-0.23.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7ca6b71dcc50d320c88fb2d88ecd63924934a8abc1673683a242a7ca7d39e781", size = 437907 },
-    { url = "https://files.pythonhosted.org/packages/fd/36/bf01f9d2f16609f8a9564c9001895df821212a14cda6e1cc25d4295c8c61/watchfiles-0.23.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2aec5c29915caf08771d2507da3ac08e8de24a50f746eb1ed295584ba1820330", size = 456983 },
-    { url = "https://files.pythonhosted.org/packages/2f/bd/6ac26a36b16182e2b6df21ac7a86c647979ae43acb6dd03eab14bee66bd8/watchfiles-0.23.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1733b9bc2c8098c6bdb0ff7a3d7cb211753fecb7bd99bdd6df995621ee1a574b", size = 472962 },
-    { url = "https://files.pythonhosted.org/packages/62/c9/94f91ad2f88f4d84a0ccea6628d47f51007f03d5e4be6718f208c55cd1f5/watchfiles-0.23.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:02ff5d7bd066c6a7673b17c8879cd8ee903078d184802a7ee851449c43521bdd", size = 481847 },
-    { url = "https://files.pythonhosted.org/packages/57/65/f3e854c5b8912d76c8fefc7c891b3df628b9110907b968faadcb8142347e/watchfiles-0.23.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18e2de19801b0eaa4c5292a223effb7cfb43904cb742c5317a0ac686ed604765", size = 428830 },
-    { url = "https://files.pythonhosted.org/packages/09/47/8287b6757a094988eb762837a8ad814525c966c2d156cd0e486d1d6ac8d5/watchfiles-0.23.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:8ada449e22198c31fb013ae7e9add887e8d2bd2335401abd3cbc55f8c5083647", size = 617265 },
-    { url = "https://files.pythonhosted.org/packages/ae/8d/fdf4efc0235dcf158e8e1e91a3f74ff2db7492c94397cdba463c0e5e6293/watchfiles-0.23.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:3af1b05361e1cc497bf1be654a664750ae61f5739e4bb094a2be86ec8c6db9b6", size = 599198 },
-    { url = "https://files.pythonhosted.org/packages/d7/34/606577c1c99ed184edda555ce37728f6f3da90865e4dcfd98020c1f23fc1/watchfiles-0.23.0-cp39-none-win32.whl", hash = "sha256:486bda18be5d25ab5d932699ceed918f68eb91f45d018b0343e3502e52866e5e", size = 264537 },
-    { url = "https://files.pythonhosted.org/packages/54/29/e5052c455ff0d8fa9625b99b11877f804bb68150d2c8b82a4b2d871fd23d/watchfiles-0.23.0-cp39-none-win_amd64.whl", hash = "sha256:d2d42254b189a346249424fb9bb39182a19289a2409051ee432fb2926bad966a", size = 276095 },
     { url = "https://files.pythonhosted.org/packages/f7/7c/135a60260dd055227eb3b38f0be5fc16409ad58c5c6636467b27991fd863/watchfiles-0.23.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:6a9265cf87a5b70147bfb2fec14770ed5b11a5bb83353f0eee1c25a81af5abfe", size = 376161 },
     { url = "https://files.pythonhosted.org/packages/5c/25/6511ed7bc826ddc2a4e879cf469621a1184719e97d63e7f723e95991ebd3/watchfiles-0.23.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9f02a259fcbbb5fcfe7a0805b1097ead5ba7a043e318eef1db59f93067f0b49b", size = 369829 },
     { url = "https://files.pythonhosted.org/packages/73/d3/00d561a66aa000251ed598f576e8bfd1c4102f9956fc06310e9b53258d3e/watchfiles-0.23.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1ebaebb53b34690da0936c256c1cdb0914f24fb0e03da76d185806df9328abed", size = 443386 },
     { url = "https://files.pythonhosted.org/packages/00/24/1c089457e39a0e6a142df8cb795a690b71f05c948bc60df4ec12359956b8/watchfiles-0.23.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd257f98cff9c6cb39eee1a83c7c3183970d8a8d23e8cf4f47d9a21329285cee", size = 429214 },
-    { url = "https://files.pythonhosted.org/packages/c4/ee/6fc9552ad1a68e68ea8209166916dc8c5824bef80c325ec36c5362277d24/watchfiles-0.23.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:556347b0abb4224c5ec688fc58214162e92a500323f50182f994f3ad33385dcb", size = 376726 },
-    { url = "https://files.pythonhosted.org/packages/e4/63/9c5c902a041d4b742ab83220137e9c7570a829db6b0a9a41b751ac5937d0/watchfiles-0.23.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:1cf7f486169986c4b9d34087f08ce56a35126600b6fef3028f19ca16d5889071", size = 371178 },
-    { url = "https://files.pythonhosted.org/packages/4b/dd/fab40f60fcfd868e000315983b996a97bb12977f2de347c1e7a40a5d1c7d/watchfiles-0.23.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f18de0f82c62c4197bea5ecf4389288ac755896aac734bd2cc44004c56e4ac47", size = 444264 },
-    { url = "https://files.pythonhosted.org/packages/3f/b5/1faa511755b72dfd0eecf2230113a55318e11d2080f659326e7f758b3b0f/watchfiles-0.23.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:532e1f2c491274d1333a814e4c5c2e8b92345d41b12dc806cf07aaff786beb66", size = 430955 },
 ]
 
 [[package]]
@@ -930,29 +866,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a1/08/af4f67b74cc6891ee1c34a77b47a3cb77081b824c3df92c1196980df9a4f/websockets-13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93b8c2008f372379fb6e5d2b3f7c9ec32f7b80316543fd3a5ace6610c5cde1b0", size = 157843 },
     { url = "https://files.pythonhosted.org/packages/b4/b7/2c991e51d48b1b98847d0a0b608508a3b687f215a2390f99cf0ee7dd2777/websockets-13.0-cp313-cp313-win32.whl", hash = "sha256:851fd0afb3bc0b73f7c5b5858975d42769a5fdde5314f4ef2c106aec63100687", size = 151763 },
     { url = "https://files.pythonhosted.org/packages/bc/0f/f06ed6485cf9cdea7d89c2f6e9d19f1be963ba5d26fb79760bfd17dd4aa5/websockets-13.0-cp313-cp313-win_amd64.whl", hash = "sha256:7d14901fdcf212804970c30ab9ee8f3f0212e620c7ea93079d6534863444fb4e", size = 152197 },
-    { url = "https://files.pythonhosted.org/packages/48/45/4ec03a34020c9a2d602d69ea993f2531226af7cfcdb5d0d92cfd0582a6d3/websockets-13.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:94c1c02721139fe9940b38d28fb15b4b782981d800d5f40f9966264fbf23dcc8", size = 150919 },
-    { url = "https://files.pythonhosted.org/packages/13/02/cda951504102b3f50ba49d458c38eb7a6331494cd81aa9d159b2b40a4398/websockets-13.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:bd4ba86513430513e2aa25a441bb538f6f83734dc368a2c5d18afdd39097aa33", size = 148573 },
-    { url = "https://files.pythonhosted.org/packages/60/05/4130ea178a16ea88aeb6360e84437791a39aafa551abc2f72191b7b07230/websockets-13.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a1ab8f0e0cadc5be5f3f9fa11a663957fecbf483d434762c8dfb8aa44948944a", size = 148817 },
-    { url = "https://files.pythonhosted.org/packages/b2/93/a9c242630164c34ca553c98100b15b46ebd47b37696d9b2cad51e4a9e680/websockets-13.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3670def5d3dfd5af6f6e2b3b243ea8f1f72d8da1ef927322f0703f85c90d9603", size = 157691 },
-    { url = "https://files.pythonhosted.org/packages/b6/c7/505bad8727e7093976e0bd664cebb2ae37ceda4b2bcb1dfdc069159fac5b/websockets-13.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6058b6be92743358885ad6dcdecb378fde4a4c74d4dd16a089d07580c75a0e80", size = 156695 },
-    { url = "https://files.pythonhosted.org/packages/00/7d/5d249a23f2ac488520d79781f5e98b0f499baf72a43377a3f07be2453fc2/websockets-13.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:516062a0a8ef5ecbfa4acbaec14b199fc070577834f9fe3d40800a99f92523ca", size = 157000 },
-    { url = "https://files.pythonhosted.org/packages/3b/45/cdda285ea79616e49471711dacf558bb6a8fe2396965971613cdfbdb23c5/websockets-13.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:da7e918d82e7bdfc6f66d31febe1b2e28a1ca3387315f918de26f5e367f61572", size = 157418 },
-    { url = "https://files.pythonhosted.org/packages/07/38/7aa54f2fde742fb74b05616b70ec3e8a277279b71e2312b0c805839accd3/websockets-13.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:9cc7f35dcb49a4e32db82a849fcc0714c4d4acc9d2273aded2d61f87d7f660b7", size = 156824 },
-    { url = "https://files.pythonhosted.org/packages/eb/f4/9ad126139934b91befb266c6a139d0e5d31f0bd1e30d9cfc7cfe9f7fbd40/websockets-13.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:f5737c53eb2c8ed8f64b50d3dafd3c1dae739f78aa495a288421ac1b3de82717", size = 156779 },
-    { url = "https://files.pythonhosted.org/packages/66/51/15fea5d84adc4e41e9034c9fbdb59fe2dcbf63c18fb8dce489d013a6e1ba/websockets-13.0-cp39-cp39-win32.whl", hash = "sha256:265e1f0d3f788ce8ef99dca591a1aec5263b26083ca0934467ad9a1d1181067c", size = 151746 },
-    { url = "https://files.pythonhosted.org/packages/9b/04/3529d2ea1c0f8c53b52c91897f61ee90f4865635293e031dd79758d79439/websockets-13.0-cp39-cp39-win_amd64.whl", hash = "sha256:4d70c89e3d3b347a7c4d3c33f8d323f0584c9ceb69b82c2ef8a174ca84ea3d4a", size = 152202 },
     { url = "https://files.pythonhosted.org/packages/e0/1e/f7260a625b210f8242d0d858a3006a54b632843b796db39d9deb90068031/websockets-13.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:602cbd010d8c21c8475f1798b705bb18567eb189c533ab5ef568bc3033fdf417", size = 148603 },
     { url = "https://files.pythonhosted.org/packages/b7/b6/3462a3a2688a62ee52aa1555fd47c61ffad0b12d0ed6ccdefd1ef8c3eef4/websockets-13.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:bf8eb5dca4f484a60f5327b044e842e0d7f7cdbf02ea6dc4a4f811259f1f1f0b", size = 148837 },
     { url = "https://files.pythonhosted.org/packages/ca/74/9f7c4669c5b5e154384eace44a5a3e24609c230f1428fea6b9af257a66c5/websockets-13.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89d795c1802d99a643bf689b277e8604c14b5af1bc0a31dade2cd7a678087212", size = 150200 },
     { url = "https://files.pythonhosted.org/packages/c0/33/a307018b358f5cca141497e95f9af19c3e8be748219773afc4fcd4791123/websockets-13.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:788bc841d250beccff67a20a5a53a15657a60111ef9c0c0a97fbdd614fae0fe2", size = 149804 },
     { url = "https://files.pythonhosted.org/packages/d9/62/c514d5b087f7b2cab8d97c80213d7ee8196b5954f8466886146c09d4fc46/websockets-13.0-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7334752052532c156d28b8eaf3558137e115c7871ea82adff69b6d94a7bee273", size = 149754 },
     { url = "https://files.pythonhosted.org/packages/f4/d7/b11dd0a18b9bd876158c463ac1a6cab7b1b38093866fce22d03ab5462258/websockets-13.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:e7a1963302947332c3039e3f66209ec73b1626f8a0191649e0713c391e9f5b0d", size = 152235 },
-    { url = "https://files.pythonhosted.org/packages/ad/e2/04f1c78d8d10fd3bc9871cdbf72384893296c983bd11be5489693ae815e8/websockets-13.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:e5ba5e9b332267d0f2c33ede390061850f1ac3ee6cd1bdcf4c5ea33ead971966", size = 148600 },
-    { url = "https://files.pythonhosted.org/packages/cd/9d/56d2a4160f9c64d5fe71d507c47a82e81354a0b42c28637c2b14b9c12ffb/websockets-13.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:f9af457ed593e35f467140d8b61d425495b127744a9d65d45a366f8678449a23", size = 148831 },
-    { url = "https://files.pythonhosted.org/packages/39/c5/8afc5f92fa44c613ccde5e8cf7c07b022b5b37467ade6b8d993739d98b34/websockets-13.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcea3eb58c09c3a31cc83b45c06d5907f02ddaf10920aaa6443975310f699b95", size = 150196 },
-    { url = "https://files.pythonhosted.org/packages/b1/1c/63ab30c9a518ccc630a12613f1e7e1ec922e2920dd986ae7d4833fdff0d7/websockets-13.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c210d1460dc8d326ffdef9703c2f83269b7539a1690ad11ae04162bc1878d33d", size = 149799 },
-    { url = "https://files.pythonhosted.org/packages/95/fa/d04a7a1a309a0a51abb2e22bef7e60604b239ca543d566738e178d11f265/websockets-13.0-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b32f38bc81170fd56d0482d505b556e52bf9078b36819a8ba52624bd6667e39e", size = 149748 },
-    { url = "https://files.pythonhosted.org/packages/95/d4/e9ac61106f7934cc75c285c38d9fb3b478963a77ffafa8b3c60823ae8992/websockets-13.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:81a11a1ddd5320429db47c04d35119c3e674d215173d87aaeb06ae80f6e9031f", size = 152229 },
     { url = "https://files.pythonhosted.org/packages/b2/89/c0be9f09eea478659e9d936210ff03e6a2a3a8d4b8dfac6b1143ff646ded/websockets-13.0-py3-none-any.whl", hash = "sha256:dbbac01e80aee253d44c4f098ab3cc17c822518519e869b284cfbb8cd16cc9de", size = 142957 },
 ]
 
@@ -963,13 +882,4 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b7/a0/95e9e962c5fd9da11c1e28aa4c0d8210ab277b1ada951d2aee336b505813/wheel-0.44.0.tar.gz", hash = "sha256:a29c3f2817e95ab89aa4660681ad547c0e9547f20e75b0562fe7723c9a2a9d49", size = 100733 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/d1/9babe2ccaecff775992753d8686970b1e2755d21c8a63be73aba7a4e7d77/wheel-0.44.0-py3-none-any.whl", hash = "sha256:2376a90c98cc337d18623527a97c31797bd02bad0033d41547043a1cbfbe448f", size = 67059 },
-]
-
-[[package]]
-name = "zipp"
-version = "3.20.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d3/8b/1239a3ef43a0d0ebdca623fb6413bc7702c321400c5fdd574f0b7aa0fbb4/zipp-3.20.1.tar.gz", hash = "sha256:c22b14cc4763c5a5b04134207736c107db42e9d3ef2d9779d465f5f1bcba572b", size = 23848 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/9e/c96f7a4cd0bf5625bb409b7e61e99b1130dc63a98cb8b24aeabae62d43e8/zipp-3.20.1-py3-none-any.whl", hash = "sha256:9960cd8967c8f85a56f920d5d507274e74f9ff813a0ab8889a5b5be2daf44064", size = 8988 },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cappa"
-version = "0.23.0"
+version = "0.24.0"
 description = "Declarative CLI argument parser."
 
 urls = {repository = "https://github.com/dancardin/cappa"}

--- a/src/cappa/__init__.py
+++ b/src/cappa/__init__.py
@@ -6,6 +6,7 @@ from cappa.file_io import FileMode
 from cappa.help import HelpFormatable, HelpFormatter
 from cappa.invoke import Dep
 from cappa.output import Exit, HelpExit, Output
+from cappa.parse import unpack_arguments
 from cappa.subcommand import Subcommand, Subcommands
 
 # isort: split
@@ -38,4 +39,5 @@ __all__ = [
     "invoke",
     "invoke_async",
     "parse",
+    "unpack_arguments",
 ]

--- a/src/cappa/destructure.py
+++ b/src/cappa/destructure.py
@@ -60,6 +60,7 @@ def restructure(root_arg: Arg, action: ArgActionType):
         action_result = action_handler(**kwargs)
 
         assert arg.parse
+        assert callable(arg.parse)
         result[arg.field_name] = arg.parse(action_result)
         return result
 

--- a/src/cappa/output.py
+++ b/src/cappa/output.py
@@ -19,14 +19,14 @@ if typing.TYPE_CHECKING:
     from cappa.command import Command
 
 __all__ = [
-    "output_format",
-    "error_format",
-    "error_format_without_short_help",
     "Displayable",
-    "theme",
-    "Output",
     "Exit",
     "HelpExit",
+    "Output",
+    "error_format",
+    "error_format_without_short_help",
+    "output_format",
+    "theme",
 ]
 
 prompt_types = (Prompt, Confirm)

--- a/src/cappa/parse.py
+++ b/src/cappa/parse.py
@@ -5,18 +5,27 @@ import types
 import typing
 from datetime import date, datetime, time
 
+from typing_extensions import Never
+
 from cappa.file_io import FileMode
 from cappa.type_view import TypeView
-from cappa.typing import T
+from cappa.typing import (
+    T,
+)
+
+if typing.TYPE_CHECKING:
+    pass
 
 __all__ = [
     "parse_list",
     "parse_literal",
-    "parse_none",
+    "parse_literal",
     "parse_set",
     "parse_tuple",
     "parse_union",
     "parse_value",
+    "parse_value",
+    "unpack_arguments",
 ]
 
 
@@ -31,19 +40,36 @@ type_priority: typing.Final = types.MappingProxyType(
     }
 )
 
-
-def wrap_type_view(fn):
-    @functools.wraps(fn)
-    def wrapper(annotation: T | TypeView[T]) -> T:
-        if not isinstance(annotation, TypeView):
-            annotation = TypeView(annotation)
-        return fn(annotation)
-
-    return wrapper
+Parser = typing.Callable[..., T]
+MaybeTypeView = typing.Union[typing.Type[T], TypeView[typing.Type[T]]]
 
 
-@wrap_type_view
-def parse_value(annotation: TypeView[T]) -> typing.Callable[[typing.Any], T]:
+def unpack_arguments(value, type_view: TypeView[T]) -> Parser:
+    """`parse=` compatible function that splats values into a dataclass-like object constructor.
+
+    For example, some `foo: Annotated[Object, Arg(parse[json.loads, splat_arguments])]` annotation
+    would unpack the result of `json.loads` into the constructor of `Object`, like `Object(**data)`.
+    """
+    origin = type_view.strip_optional().fallback_origin
+    mapper = origin
+
+    value_type_view = TypeView(type(value))
+    if value_type_view.is_mapping:
+        return origin(**value)
+
+    if value_type_view.is_collection and not value_type_view.is_subclass_of(str):
+        return origin(*value)
+
+    return mapper(value)
+
+
+def _as_type_view(typ: T | TypeView[T]) -> TypeView[T]:
+    if isinstance(typ, TypeView):
+        return typ
+    return TypeView(typ)
+
+
+def parse_value(typ: MaybeTypeView) -> Parser[T]:
     """Create a value parser for the given annotation.
 
     Examples:
@@ -52,46 +78,48 @@ def parse_value(annotation: TypeView[T]) -> typing.Callable[[typing.Any], T]:
         >>> tuple_parser = parse_value(Tuple[int, ...])
         >>> literal_parser = parse_literal(Literal["foo"])
     """
-    if annotation.is_literal:
-        return parse_literal(annotation)
+    type_view = _as_type_view(typ)
 
-    if annotation.is_union:
-        return parse_union(annotation)
+    if type_view.is_literal:
+        return parse_literal(type_view)
 
-    if annotation.is_subclass_of((str, bool, int, float)):
-        return annotation.annotation
+    if type_view.is_union:
+        return parse_union(type_view)
 
-    if annotation.is_none_type:
-        return parse_none  # type: ignore
+    if type_view.is_subclass_of((str, bool, int, float)):
+        return type_view.annotation
 
-    if annotation.is_subclass_of(datetime):
+    if type_view.is_none_type:
+        return parse_none
+
+    if type_view.is_subclass_of(datetime):
         return datetime.fromisoformat  # type: ignore
 
-    if annotation.is_subclass_of(date):
+    if type_view.is_subclass_of(date):
         return date.fromisoformat  # type: ignore
 
-    if annotation.is_subclass_of(time):
+    if type_view.is_subclass_of(time):
         return time.fromisoformat  # type: ignore
 
-    if annotation.is_subclass_of(list):
-        return parse_list(annotation)  # pyright: ignore
+    if type_view.is_subclass_of(list):
+        return parse_list(type_view)  # type: ignore
 
-    if annotation.is_subclass_of(set):
-        return parse_set(annotation)  # pyright: ignore
+    if type_view.is_subclass_of(set):
+        return parse_set(type_view)  # type: ignore
 
-    if annotation.is_subclass_of(tuple):
-        return parse_tuple(annotation)  # pyright: ignore
+    if type_view.is_subclass_of(tuple):
+        return parse_tuple(type_view)  # type: ignore
 
-    if annotation.is_subclass_of((typing.TextIO, typing.BinaryIO)):
-        return parse_file_io(annotation)
+    if type_view.is_subclass_of((typing.TextIO, typing.BinaryIO)):
+        return parse_file_io(type_view)
 
-    return annotation.annotation
+    return type_view.annotation
 
 
-@wrap_type_view
-def parse_literal(annotation: TypeView[T]) -> typing.Callable[[typing.Any], T]:
+def parse_literal(typ: MaybeTypeView) -> Parser[T]:
     """Create a value parser for a given literal value."""
-    unique_type_args = set(annotation.args)
+    type_view = _as_type_view(typ)
+    unique_type_args = set(type_view.args)
 
     def literal_mapper(value):
         if value in unique_type_args:
@@ -102,7 +130,7 @@ def parse_literal(annotation: TypeView[T]) -> typing.Callable[[typing.Any], T]:
             if raw_value == value:
                 return type_arg
 
-        options = ", ".join(f"'{t}'" for t in annotation.args)
+        options = ", ".join(f"'{t}'" for t in type_view.args)
         raise ValueError(
             f"Invalid choice: '{value}' (choose from literal values {options})"
         )
@@ -110,10 +138,10 @@ def parse_literal(annotation: TypeView[T]) -> typing.Callable[[typing.Any], T]:
     return literal_mapper
 
 
-@wrap_type_view
-def parse_list(annotation: TypeView[list[T]]) -> typing.Callable[[typing.Any], list[T]]:
+def parse_list(typ: MaybeTypeView[list[T]]) -> Parser[list[T]]:
     """Create a value parser for a list of given type `of_type`."""
-    inner_mapper = parse_value(annotation.inner_types[0])
+    type_view = _as_type_view(typ)
+    inner_mapper: Parser[T] = parse_value(type_view.inner_types[0])
 
     def list_mapper(value: list[typing.Any]) -> list[T]:
         return [inner_mapper(v) for v in value]
@@ -121,10 +149,10 @@ def parse_list(annotation: TypeView[list[T]]) -> typing.Callable[[typing.Any], l
     return list_mapper
 
 
-@wrap_type_view
-def parse_set(annotation: TypeView[list[T]]) -> typing.Callable[[typing.Any], set[T]]:
+def parse_set(typ: MaybeTypeView[list[T]]) -> Parser[set[T]]:
     """Create a value parser for a list of given type `of_type`."""
-    inner_mapper = parse_value(annotation.inner_types[0])
+    type_view = _as_type_view(typ)
+    inner_mapper: Parser[T] = parse_value(type_view.inner_types[0])
 
     def set_mapper(value: list[typing.Any]) -> set[T]:
         return {inner_mapper(v) for v in value}
@@ -132,12 +160,12 @@ def parse_set(annotation: TypeView[list[T]]) -> typing.Callable[[typing.Any], se
     return set_mapper
 
 
-@wrap_type_view
-def parse_tuple(annotation: TypeView[T]) -> typing.Callable[[typing.Any], tuple[T]]:
+def parse_tuple(typ: MaybeTypeView[T]) -> Parser[tuple[T]]:
     """Create a value parser for a tuple with type-args of given `type_args`."""
-    if annotation.is_variadic_tuple:
-        assert annotation.args
-        inner_type = annotation.args[0]
+    type_view = _as_type_view(typ)
+    if type_view.is_variadic_tuple:
+        assert type_view.args
+        inner_type = type_view.args[0]
         list_mapper = parse_list(typing.List[inner_type])  # type: ignore
 
         def unbounded_tuple_mapper(value: list):
@@ -147,8 +175,8 @@ def parse_tuple(annotation: TypeView[T]) -> typing.Callable[[typing.Any], tuple[
 
     def tuple_mapper(value: list):
         result = []
-        for inner_type, inner_value in zip(annotation.inner_types, value):
-            inner_mapper = parse_value(inner_type)
+        for inner_type, inner_value in zip(type_view.inner_types, value):
+            inner_mapper: Parser[T] = parse_value(inner_type)
             inner_value = inner_mapper(inner_value)
             result.append(inner_value)
         return tuple(result)
@@ -156,17 +184,11 @@ def parse_tuple(annotation: TypeView[T]) -> typing.Callable[[typing.Any], tuple[
     return tuple_mapper
 
 
-@wrap_type_view
-def parse_union(annotation: TypeView[T]) -> typing.Callable[[typing.Any], T]:
+def parse_union(typ: MaybeTypeView[T]) -> Parser[T]:
     """Create a value parser for a Union with type-args of given `type_args`."""
 
     def type_priority_key(type_type_view: TypeView) -> int:
         return type_priority.get(type_type_view.annotation, 1)
-
-    mappers: list[tuple[TypeView[T], typing.Callable]] = [
-        (t, parse_value(t))
-        for t in sorted(annotation.inner_types, key=type_priority_key)
-    ]
 
     def union_mapper(value):
         exceptions = []
@@ -186,10 +208,16 @@ def parse_union(annotation: TypeView[T]) -> typing.Callable[[typing.Any], T]:
         reasons = "\n".join(exceptions)
         raise ValueError(f"Possible variants\n{reasons}")
 
+    type_view = _as_type_view(typ)
+    mappers: list[tuple[TypeView[T], typing.Callable]] = [
+        (t, parse_value(t))
+        for t in sorted(type_view.inner_types, key=type_priority_key)
+    ]
+
     return union_mapper
 
 
-def parse_none(value: typing.Any) -> None:
+def parse_none(value: typing.Any) -> Never:
     """Create a value parser for None.
 
     Default values are not run through Arg.parse, so there's no way to arrive at a `None` value.
@@ -197,21 +225,56 @@ def parse_none(value: typing.Any) -> None:
     raise ValueError(value)
 
 
-@wrap_type_view
-def parse_file_io(annotation: TypeView) -> typing.Callable:
-    def file_io_mapper(value: str):
+def parse_file_io(typ: MaybeTypeView[T]) -> Parser[T]:
+    type_view = _as_type_view(typ)
+
+    def file_io_mapper(value: str) -> T:
         try:
             file_mode: FileMode = next(
                 typing.cast(FileMode, f)
-                for f in annotation.metadata
+                for f in type_view.metadata
                 if isinstance(f, FileMode)
             )
         except StopIteration:
             file_mode = FileMode()
 
-            if annotation.is_subclass_of(typing.BinaryIO):
+            if type_view.is_subclass_of(typing.BinaryIO):
                 file_mode.mode += "b"
 
         return file_mode(value)
 
     return file_io_mapper
+
+
+def evaluate_parse(
+    parsers: Parser[T] | typing.Sequence[Parser[typing.Any]],
+    type_view: TypeView[T],
+):
+    from cappa.invoke import fulfill_deps
+
+    if callable(parsers):
+        parsers = [parsers]
+
+    parsers = [
+        functools.partial(
+            parser,
+            **fulfill_deps(
+                parser,
+                {TypeView: type_view},
+                allow_empty=True,
+            ),
+        )
+        for parser in parsers
+    ]
+
+    if len(parsers) == 1:
+        return parsers[0]
+
+    def sequence_parsers(value):
+        result = value
+        for parser in parsers:
+            result = parser(result)
+
+        return result
+
+    return sequence_parsers

--- a/tests/arg/test_parse.py
+++ b/tests/arg/test_parse.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Union
 
 import pytest
+from type_lens.type_view import TypeView
 from typing_extensions import Annotated
 
 import cappa
@@ -59,7 +60,7 @@ def test_parse_failure(backend):
 
 @backends
 def test_parse_optional(backend):
-    """An explicit exit takes message precedence, and do not include extra cappa text."""
+    """Optionals are handled by the given/inferred parse method."""
 
     @dataclass
     class ArgTest:
@@ -97,3 +98,35 @@ def test_parse_returns_none(backend):
 
     result = parse(ArgTest, "2", backend=backend)
     assert result == ArgTest(None)
+
+
+def parser_test_typed_parse(value: str):
+    return float(value)
+
+
+@backends
+def test_typed_parse(backend):
+    """A parse function with a typed argument."""
+
+    @dataclass
+    class ArgTest:
+        num: Annotated[float, cappa.Arg(parse=parser_test_typed_parse)]
+
+    result = parse(ArgTest, "4.1", backend=backend)
+    assert result == ArgTest(num=4.1)
+
+
+def parser_test_type_aware_parse(value: str, type_view: TypeView):
+    return str(type_view)
+
+
+@backends
+def test_type_aware_parse(backend):
+    """A parse function that receives type information."""
+
+    @dataclass
+    class ArgTest:
+        num: Annotated[str, cappa.Arg(parse=parser_test_type_aware_parse)]
+
+    result = parse(ArgTest, "4.1", backend=backend)
+    assert result == ArgTest(num="TypeView(str)")

--- a/tests/arg/test_parse_dataclass_like.py
+++ b/tests/arg/test_parse_dataclass_like.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Union
+
+from typing_extensions import Annotated
+
+import cappa
+from cappa.parse import unpack_arguments
+from tests.utils import backends, parse
+
+
+@dataclass
+class Single:
+    value: str
+
+
+@dataclass
+class Double:
+    one: str
+    two: str
+
+
+@dataclass
+class Mapping:
+    foo: str
+    bar: str
+
+
+@dataclass
+class Args:
+    single: Annotated[
+        Union[Single, None], cappa.Arg(long=True, parse=unpack_arguments)
+    ] = None
+    double: Annotated[
+        Union[Double, None],
+        cappa.Arg(long=True, num_args=2, parse=unpack_arguments),
+    ] = None
+    mapping: Annotated[
+        Union[Mapping, None],
+        cappa.Arg(long=True, parse=[json.loads, unpack_arguments]),
+    ] = None
+
+
+@backends
+def test_dataclass_annotation(backend):
+    """Dataclass annotation will supply or splat arguments, depending on input shape."""
+    result = parse(Args, backend=backend)
+    assert result == Args()
+
+    result = parse(Args, "--single=3", backend=backend)
+    assert result.single == Single("3")
+    assert result.double is None
+    assert result.mapping is None
+
+    result = parse(Args, "--double", "5", "10", backend=backend)
+    assert result.single is None
+    assert result.double == Double(one="5", two="10")
+    assert result.mapping is None
+
+    result = parse(Args, '--mapping={"foo": "8", "bar": "3"}', backend=backend)
+    assert result.single is None
+    assert result.double is None
+    assert result.mapping == Mapping(foo="8", bar="3")

--- a/tests/test_manually_built.py
+++ b/tests/test_manually_built.py
@@ -20,7 +20,7 @@ class Foo:
 command = cappa.Command(
     Foo,
     arguments=[
-        cappa.Arg(field_name="bar", parse=str),
+        cappa.Arg(field_name="bar"),
         cappa.Arg(field_name="baz", parse=parse_list(List[int]), num_args=-1),
     ],
     help="Short help.",
@@ -45,18 +45,20 @@ def test_help(capsys, backend):
     assert "Long description." in out
 
 
+@dataclass
+class Bar:
+    bar: str
+
+
+@dataclass
+class Foo2:
+    sub: Bar
+
+
 @backends
 def test_subcommand(backend):
-    @dataclass
-    class Bar:
-        bar: str
-
-    @dataclass
-    class Foo:
-        sub: Bar
-
     command = cappa.Command(
-        Foo,
+        Foo2,
         arguments=[
             cappa.Subcommand(
                 field_name="sub",
@@ -64,7 +66,7 @@ def test_subcommand(backend):
                     "bar": cappa.Command(
                         Bar,
                         arguments=[
-                            cappa.Arg(field_name="bar", parse=parse_value),
+                            cappa.Arg(field_name="bar", parse=parse_value(str)),
                         ],
                     )
                 },
@@ -75,4 +77,4 @@ def test_subcommand(backend):
     )
 
     result = parse(command, "bar", "one", backend=backend)
-    assert result == Foo(sub=Bar("one"))
+    assert result == Foo2(sub=Bar("one"))

--- a/uv.lock
+++ b/uv.lock
@@ -28,7 +28,7 @@ wheels = [
 
 [[package]]
 name = "cappa"
-version = "0.23.0"
+version = "0.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
~This is probably blocked on https://github.com/DanCardin/cappa/pull/117. Realistically, the current `annotation` and `extra_annotations` used by the parsers is bad DX in comparison to something like `TypeView`. If all the parsers are going to end up refactored to be defined in terms of single-level value/annotation, it's going to make a lot more sense when the actual annotation bit is a TypeView instead.~

Result based of discussion from https://github.com/DanCardin/cappa/discussions/137

The main problem with automatic dataclass-like inference, is that we can't know, without the annotation and an explicit decision from the user, whether a `list[T]` input is the appropriate input for the class itself, or if it wants the inputs to be splatted into the constructor.

For anything where the single value would make sense today, it should already work.

---

~As implemented, this is perhaps a decent amount more complicated because it's using the `invoke` machinery to apply all `parse` operations now. It's not necessarily a problem, it's just a decent amount more code being evaluated for every parameter to introspect the function's parameter annotations before calling the function, versus just calling the function.~

It's now **moderately** more complicated at the collection phase, but not overly so, and the actual parse step is no more complicated. And `compose` can be handled with lists of parsers, which is the biggest simplification.