### PR TITLE
feat: Introduce `Arg.destructure()` and `Arg.has_value`.

### DIFF
--- a/src/cappa/command.py
+++ b/src/cappa/command.py
@@ -6,7 +6,7 @@ import typing
 from collections.abc import Callable
 
 from cappa import class_inspect
-from cappa.arg import Arg, ArgAction, Group
+from cappa.arg import Arg, Group
 from cappa.docstring import ClassHelpText
 from cappa.env import Env
 from cappa.help import HelpFormatable, HelpFormatter, format_short_help
@@ -199,7 +199,7 @@ class Command(typing.Generic[T]):
                 if is_subcommand:
                     continue
 
-                assert arg.default is not Empty
+                assert arg.default is not Empty, arg
                 value = arg.default
 
             else:
@@ -231,9 +231,8 @@ class Command(typing.Generic[T]):
 
     def value_arguments(self):
         for arg in self.arguments:
-            if isinstance(arg, Arg):
-                if arg.action in ArgAction.value_actions():
-                    continue
+            if isinstance(arg, Arg) and not arg.has_value:
+                continue
 
             yield arg
 

--- a/src/cappa/destructure.py
+++ b/src/cappa/destructure.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from type_lens import TypeView
+
+from cappa.arg import Arg, ArgActionType
+from cappa.invoke import fulfill_deps
+from cappa.output import Output
+from cappa.parser import ParseContext, Value, determine_action_handler
+from cappa.typing import assert_type
+
+
+@dataclass
+class Destructured: ...
+
+
+def destructure(arg: Arg, type_view: TypeView):
+    if not isinstance(type_view.annotation, type):
+        raise ValueError(
+            "Destructured arguments currently only support singular concrete types."
+        )
+
+    command: Command = Command.get(type_view.annotation)
+    virtual_args = Command.collect(command).arguments
+
+    arg.parse = lambda v: command.cmd_cls(**v)
+
+    result = [arg]
+    for virtual_arg in virtual_args:
+        if isinstance(virtual_arg, Subcommand):
+            raise ValueError(
+                "Subcommands are unsupported in the context of a destructured argument"
+            )
+
+        assert virtual_arg.action
+        virtual_arg.action = restructure(arg, virtual_arg.action)
+        virtual_arg.has_value = False
+
+        result.append(virtual_arg)
+
+    return result
+
+
+def restructure(root_arg: Arg, action: ArgActionType):
+    action_handler = determine_action_handler(action)
+
+    def restructure_action(context: ParseContext, arg: Arg, value: Value):
+        root_field_name = assert_type(root_arg.field_name, str)
+        result = context.result.setdefault(root_field_name, {})
+
+        fulfilled_deps: dict = {
+            Command: context.command,
+            Output: context.output,
+            ParseContext: context,
+            Arg: arg,
+            Value: value,
+        }
+        kwargs = fulfill_deps(action_handler, fulfilled_deps)
+        action_result = action_handler(**kwargs)
+
+        assert arg.parse
+        result[arg.field_name] = arg.parse(action_result)
+        return result
+
+    return restructure_action
+
+
+from cappa.command import Command  # noqa: E402
+from cappa.subcommand import Subcommand  # noqa: E402

--- a/src/cappa/help.py
+++ b/src/cappa/help.py
@@ -41,6 +41,7 @@ def create_version_arg(version: str | Arg | None = None) -> Arg | None:
             long=["--version"],
             help="Show the version and exit.",
             group=(4, "Help"),
+            action=ArgAction.version,
         )
 
     if version.value_name is Empty:
@@ -66,6 +67,7 @@ def create_help_arg(help: bool | Arg | None = True) -> Arg | None:
             long=["--help"],
             help="Show this message and exit.",
             group=(4, "Help"),
+            action=ArgAction.help,
         )
 
     return help.normalize(action=ArgAction.help, field_name="help", default=None)
@@ -81,6 +83,7 @@ def create_completion_arg(completion: bool | Arg = True) -> Arg | None:
             choices=["generate", "complete"],
             group=(4, "Help"),
             help="Use `--completion generate` to print shell-specific completion source.",
+            action=ArgAction.completion,
         )
 
     return completion.normalize(

--- a/tests/arg/test_destructured.py
+++ b/tests/arg/test_destructured.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+
+import pytest
+from typing_extensions import Annotated
+
+import cappa
+from tests.utils import parse
+
+
+class Flavor(enum.Enum):
+    vanilla = "vanilla"
+    chocolate = "chocolate"
+
+
+@dataclass
+class Attributes:
+    color: Annotated[str, cappa.Arg(long="attribute.color")]
+    flavors: Annotated[list[Flavor], cappa.Arg(value_name="attribute.flavor")]
+    something: Annotated[int, cappa.Arg(short="-p")]
+    custom_parse: Annotated[str, cappa.Arg(long="foo", parse=lambda _: "always this")]
+    custom_action: Annotated[int, cappa.Arg(long="bar", action=lambda: 42)]
+    optional: Annotated[int, cappa.Arg(long="baz")] = 4
+
+
+@dataclass
+class Args:
+    attrs: Annotated[Attributes, cappa.Arg.destructure()]
+
+
+def test_destructured():
+    test = parse(
+        Args,
+        "--attribute.color=red",
+        "chocolate",
+        "vanilla",
+        "-p4",
+        "--foo=whatever",
+        "--bar=0",
+    )
+    assert test == Args(
+        attrs=Attributes(
+            "red",
+            [Flavor.chocolate, Flavor.vanilla],
+            something=4,
+            custom_parse="always this",
+            custom_action=42,
+            optional=4,
+        )
+    )
+
+
+@dataclass
+class OptionalArgs:
+    attrs: Annotated[Attributes | None, cappa.Arg.destructure()]
+
+
+def test_destructured_optional():
+    with pytest.raises(ValueError) as e:
+        parse(OptionalArgs)
+    assert (
+        str(e.value)
+        == "Destructured arguments currently only support singular concrete types."
+    )


### PR DESCRIPTION
An idea that came out of https://github.com/DanCardin/cappa/discussions/137. Basically, by fanning out CLI parameters on a nested object into the containing command structure.