### PR TITLE
fix: invoke(help_formatter=...) not applying to explicitly decorated commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.24
 
+### 0.24.1
+
+- feat: Add Group.section to enable ordering of groups separately from the items within them.
+- fix: invoke(help_formatter=...) not applying to explicitly decorated commands.
+
 ### 0.24.0
 - feat: Support native inference parser for dataclass-like annotation
 s.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cappa"
-version = "0.24.0"
+version = "0.24.1"
 description = "Declarative CLI argument parser."
 
 urls = {repository = "https://github.com/dancardin/cappa"}

--- a/src/cappa/command.py
+++ b/src/cappa/command.py
@@ -81,17 +81,23 @@ class Command(typing.Generic[T]):
     def get(
         cls, obj: type[T] | Command[T], help_formatter: HelpFormatable | None = None
     ) -> Command[T]:
-        if isinstance(obj, cls):
-            return obj
+        help_formatter = help_formatter or HelpFormatter.default
 
-        obj = class_inspect.get_command_capable_object(obj)
-        if getattr(obj, "__cappa__", None):
-            return obj.__cappa__  # type: ignore
+        instance = None
+        if isinstance(obj, cls):
+            instance = obj
+        else:
+            obj = class_inspect.get_command_capable_object(obj)
+            if getattr(obj, "__cappa__", None):
+                instance = obj.__cappa__  # type: ignore
+
+        if instance:
+            return dataclasses.replace(instance, help_formatter=help_formatter)
 
         assert not isinstance(obj, Command)
         return cls(
             obj,
-            help_formatter=help_formatter or HelpFormatter.default,
+            help_formatter=help_formatter,
         )
 
     def real_name(self) -> str:

--- a/tests/arg/test_show_default.py
+++ b/tests/arg/test_show_default.py
@@ -6,7 +6,7 @@ import pytest
 from typing_extensions import Annotated
 
 import cappa
-from tests.utils import TestOutput, backends, parse
+from tests.utils import CapsysOutput, backends, parse
 
 
 @backends
@@ -20,7 +20,7 @@ def test_show_default_default_true(backend, capsys):
     with pytest.raises(cappa.HelpExit):
         parse(Command, "--help", backend=backend)
 
-    output = TestOutput.from_capsys(capsys)
+    output = CapsysOutput.from_capsys(capsys)
     assert "(Default: False)" in output.stdout
 
 
@@ -35,7 +35,7 @@ def test_show_default_set_false(backend, capsys):
     with pytest.raises(cappa.HelpExit):
         parse(Command, "--help", backend=backend)
 
-    output = TestOutput.from_capsys(capsys)
+    output = CapsysOutput.from_capsys(capsys)
     assert "(Default: False)" not in output.stdout
 
 
@@ -50,7 +50,7 @@ def test_show_default_no_option_shows_for_false_default(backend, capsys):
     with pytest.raises(cappa.HelpExit):
         parse(Command, "--help", backend=backend)
 
-    stdout = TestOutput.from_capsys(capsys).stdout.replace(" ", "")
+    stdout = CapsysOutput.from_capsys(capsys).stdout.replace(" ", "")
     assert "[--foo](Default:True)" not in stdout
     assert "[--no-foo](Default:False)" in stdout
 
@@ -66,6 +66,6 @@ def test_show_default_no_option_shows_for_true_default(backend, capsys):
     with pytest.raises(cappa.HelpExit):
         parse(Command, "--help", backend=backend)
 
-    stdout = TestOutput.from_capsys(capsys).stdout.replace(" ", "")
+    stdout = CapsysOutput.from_capsys(capsys).stdout.replace(" ", "")
     assert "[--foo](Default:True)" in stdout
     assert "[--no-foo](Default:False)" not in stdout

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -61,7 +61,7 @@ def strip_trailing_whitespace(text):
 
 
 @dataclass
-class TestOutput:
+class CapsysOutput:
     stdout: str
     stderr: str
 


### PR DESCRIPTION
Fixes https://github.com/DanCardin/cappa/issues/173