### PR TITLE
fix: Perform choices validation after parse/mapping time.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.25
 
+### 0.25.1
+
+- fix: Perform choices validation after parse/mapping time.
+
 ### 0.25.0
 
 - feat: Add `Arg.propagate`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cappa"
-version = "0.25.0"
+version = "0.25.1"
 description = "Declarative CLI argument parser."
 
 urls = {repository = "https://github.com/dancardin/cappa"}

--- a/src/cappa/argparse.py
+++ b/src/cappa/argparse.py
@@ -250,8 +250,8 @@ def add_argument(
     elif is_positional and not arg.required:
         kwargs["nargs"] = "?"
 
-    if arg.choices:
-        kwargs["choices"] = arg.choices
+    # if arg.choices:
+    #     kwargs["choices"] = arg.choices
 
     deprecated_kwarg = add_deprecated_kwarg(arg)
     kwargs.update(deprecated_kwarg)

--- a/src/cappa/parser.py
+++ b/src/cappa/parser.py
@@ -578,15 +578,6 @@ def consume_arg(
     if orig_num_args == 1:
         if result:
             result = result[0]
-            if arg.choices and result not in arg.choices:
-                choices = ", ".join(f"'{c}'" for c in arg.choices)
-                raise BadArgumentError(
-                    f"Invalid choice: '{result}' (choose from {choices})",
-                    value=result,
-                    command=parse_state.current_command,
-                    arg=arg,
-                )
-
             if parse_state.provide_completions and not parse_state.has_values():
                 if arg.completion:
                     completions: list[Completion] | list[FileCompletion] = (
@@ -645,6 +636,7 @@ def consume_arg(
         ParseState: parse_state,
         Arg: arg,
         Value: Value(result),
+        typing.Any: result,
     }
     if option:
         fulfilled_deps[RawOption] = option

--- a/tests/arg/test_choices.py
+++ b/tests/arg/test_choices.py
@@ -72,3 +72,18 @@ def test_tuple_choices(backend, capsys):
 
     result = capsys.readouterr().out
     assert "Valid options: one, two." not in result
+
+
+@backends
+def test_literal_parse_sequence(backend):
+    @dataclass
+    class LiteralParse:
+        log_level: Annotated[
+            str,
+            cappa.Arg(
+                short="-L", long=True, choices=["DEBUG"], parse=[str.upper, str.strip]
+            ),
+        ] = "DEBUG"
+
+    result = parse(LiteralParse, "--log-level", "  debug  ", backend=backend)
+    assert result == LiteralParse(log_level="DEBUG")

--- a/tests/arg/test_literal.py
+++ b/tests/arg/test_literal.py
@@ -11,31 +11,52 @@ import cappa
 from tests.utils import backends, parse
 
 
-@dataclass
-class ArgTest:
-    name: Union[Literal["one"], Literal["two"], Literal["three"], Literal[4]]
-
-
 @backends
 def test_valid(backend):
+    @dataclass
+    class ArgTest:
+        name: Literal["one", "two"]
+
     test = parse(ArgTest, "two", backend=backend)
     assert test.name == "two"
 
 
 @backends
 def test_valid_int(backend):
+    @dataclass
+    class ArgTest:
+        name: Literal["one", 4]
+
     test = parse(ArgTest, "4", backend=backend)
     assert test.name == 4
 
 
 @backends
 def test_invalid(backend):
+    @dataclass
+    class ArgTest:
+        name: Literal["one", "two", "three", 4]
+
+    with pytest.raises(cappa.Exit) as e:
+        parse(ArgTest, "thename", backend=backend)
+
+    message = str(e.value.message).lower()
+    assert "invalid choice: 'thename' (choose from 'one', 'two', 'three', 4)" in message
+
+
+@backends
+def test_unioned_literals(backend):
+    @dataclass
+    class ArgTest:
+        name: Union[Literal["one"], Literal["two"], Literal["three"], Literal[4]]
+
     with pytest.raises(cappa.Exit) as e:
         parse(ArgTest, "thename", backend=backend)
 
     message = str(e.value.message).lower()
     assert (
-        "invalid choice: 'thename' (choose from 'one', 'two', 'three', '4')" in message
+        "invalid value for 'name': possible variants\n - literal['one']: invalid choice: 'thename' (choose from 'one')\n - literal['two']: invalid choice: 'thename' (choose from 'two')\n - literal['three']: invalid choice: 'thename' (choose from 'three')\n - literal[4]: invalid choice: 'thename' (choose from 4)"
+        == message
     )
 
 
@@ -55,8 +76,21 @@ def test_invalid_collection_of_literals(backend):
     err = textwrap.dedent(
         """\
         Invalid value for '-f': Possible variants
-         - set[Literal['one', 'two']]: Invalid choice: 'three' (choose from literal values 'one', 'two')
+         - set[Literal['one', 'two']]: Invalid choice: 'three' (choose from 'one', 'two')
          - list[int]: invalid literal for int() with base 10: 'three'
          - <no value>"""
     )
     assert str(e.value.message).lower() == err.lower()
+
+
+@backends
+def test_literal_parse(backend):
+    @dataclass
+    class LiteralParse:
+        log_level: Annotated[
+            Literal["TRACE", "DEBUG", "INFO"],
+            cappa.Arg(short="-L", long=True, parse=str.upper),
+        ] = "INFO"
+
+    result = parse(LiteralParse, "--log-level=debug", backend=backend)
+    assert result == LiteralParse(log_level="DEBUG")

--- a/tests/arg/test_literal_intermixed_union.py
+++ b/tests/arg/test_literal_intermixed_union.py
@@ -37,7 +37,7 @@ def test_invalid_string(backend):
     err = textwrap.dedent(
         """\
         Invalid value for 'name': Possible variants
-         - Literal['one']: Invalid choice: 'thename' (choose from literal values 'one')
+         - Literal['one']: Invalid choice: 'thename' (choose from 'one')
          - int: invalid literal for int() with base 10: 'thename'"""
     )
     assert err in str(e.value.message)

--- a/tests/arg/test_literal_mulitple_variant.py
+++ b/tests/arg/test_literal_mulitple_variant.py
@@ -26,6 +26,4 @@ def test_literal(backend):
         parse(ArgTest, "thename", backend=backend)
 
     message = str(e.value.message).lower()
-    assert (
-        "invalid choice: 'thename' (choose from 'one', 'two', 'three', '4')" in message
-    )
+    assert "invalid choice: 'thename' (choose from 'one', 'two', 'three', 4)" in message

--- a/tests/arg/test_literal_sequence.py
+++ b/tests/arg/test_literal_sequence.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Union
 
 import pytest
 from typing_extensions import Annotated, Literal
@@ -13,15 +12,15 @@ from tests.utils import backends, parse
 @dataclass
 class ArgTest:
     list: Annotated[
-        list[Union[Literal["one"], Literal["two"], Literal["three"], Literal[4]]],
+        list[Literal["one", "two", "three", 4]],
         cappa.Arg(short=True, default=[]),
     ]
     tuple: Annotated[
-        tuple[Union[Literal["one"], Literal["two"], Literal["three"], Literal[4]], ...],
+        tuple[Literal["one", "two", "three", 4], ...],
         cappa.Arg(short=True, default=()),
     ]
     set: Annotated[
-        set[Union[Literal["one"], Literal["two"], Literal["three"], Literal[4]]],
+        set[Literal["one", "two", "three", 4]],
         cappa.Arg(short=True, default=set()),
     ]
 
@@ -50,4 +49,4 @@ def test_invalid(backend):
         parse(ArgTest, "-l", "one", "-l", "wat", backend=backend)
 
     message = str(e.value.message).lower()
-    assert "invalid choice: 'wat' (choose from 'one', 'two', 'three', '4')" in message
+    assert "invalid choice: 'wat' (choose from 'one', 'two', 'three', 4)" in message

--- a/uv.lock
+++ b/uv.lock
@@ -28,7 +28,7 @@ wheels = [
 
 [[package]]
 name = "cappa"
-version = "0.24.2"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
Fixes https://github.com/DanCardin/cappa/issues/170.

~Although i still want to look at this a little bit more. this does add some weird code duplication/different branches. Although I suppose some of that already existed before, it was just built into the parser.~

In order to avoid needing to physically manipulate the annotations, this PR drops the nicer "choices" `invalid choice: 'thename' (choose from 'one', 'two', 'three', 4)`-style error messages for annotations like `Union[Literal['one'], Literal['two']]`, because it becomes impractical to support.

Instead such annotations get the union-like error message

```
invalid value for 'name': possible variants
 - literal['one']: invalid choice: 'foo'
 - literal['two']: invalid choice: 'foo'
```

which is still clear, but not as nice and concise. I think given that unions of only literals (which was the condition for this to work can and probably **should** be trivially converted to just a literal, this seems like a worthwhile tradeoff.