### PR TITLE
feat: Add DefaultFormatter as optional input to `show_default`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - fix: Skip non-init fields in dataclasses.
 - fix: Required positional arguments in the native parser.
 - fix: Infer num_args on unbounded sequence options (e.g. `list[list[str]]` annotation on an option).
+- feat: Add DefaultFormatter as optional input to `show_default`.
 
 ## 0.25
 

--- a/docs/source/arg.md
+++ b/docs/source/arg.md
@@ -297,6 +297,36 @@ As noted above, a value produced by `ValueFrom` **does not** invoke the `Arg.par
 because the called function is programmer-supplied and can/should just return the correct end
 value.
 
+## `Arg.show_default`
+
+Defaults to `True` (e.g. `DefaultFormatter(format='{default}', show=True)`). This field controls **both**:
+
+* Whether to render the argument's default for helptext
+* The formatting for the default value itself.
+
+`show_default` can be provided as any of:
+
+* `bool`: Implies the `DefaultFormatter.show` value  (e.g. `DefaultFormatter(show=<the bool>)`).
+* `str`: Implies the `DefaultFormatter.format` value (e.g. `DefaultFormatter(format=<the str>, show=True)`).
+* `DefaultFormatter`: Is taken as-is.
+
+`DefaultFormatter.show` enables/disables the display of the given `Arg.default`. While
+the literal default value is formatted through `DefaultFormatter.format`.
+
+```{info}
+The `str.format` context is provided as named `default` format arg. That is to say, the literal
+default value can be templated into the string through the named `{default}` syntax.
+
+Normal format specifiers can be used to control formatting of the value, for example `{default:.2f}`
+to limit the precision of a default float value.
+```
+
+```{note}
+The `format` value **can** simply be a static string, to avoid taking the literal default value. An
+reasonable example of this might be `source: Annotated[BinaryIO, Arg(show_default='<stdin>')] = '-'`.
+```
+
+
 (arg-group)=
 ## `Arg.group`: Groups (and Mutual Exclusion)
 

--- a/src/cappa/help.py
+++ b/src/cappa/help.py
@@ -13,7 +13,7 @@ from rich.text import Text
 from typing_extensions import Self, TypeAlias
 
 from cappa.arg import Arg, ArgAction, Group
-from cappa.default import Default
+from cappa.default import Default, DefaultFormatter
 from cappa.output import Displayable
 from cappa.subcommand import Subcommand
 from cappa.type_view import Empty
@@ -163,10 +163,12 @@ def format_arg(help_formatter: HelpFormatter, arg: Arg) -> str:
 
     segments = []
     for format_segment in arg_format:
-        default = ""
         assert isinstance(arg.default, Default)
-        if arg.show_default and arg.default.default not in (None, Empty):
-            default = help_formatter.default_format.format(default=arg.default.default)
+        assert isinstance(arg.show_default, DefaultFormatter)
+
+        default = arg.show_default.format_default(
+            arg.default, help_formatter.default_format
+        )
 
         choices = ""
         if arg.choices:

--- a/tests/arg/test_show_default.py
+++ b/tests/arg/test_show_default.py
@@ -6,6 +6,7 @@ import pytest
 from typing_extensions import Annotated
 
 import cappa
+from cappa.default import DefaultFormatter
 from tests.utils import CapsysOutput, backends, parse
 
 
@@ -69,3 +70,31 @@ def test_show_default_no_option_shows_for_true_default(backend, capsys):
     stdout = CapsysOutput.from_capsys(capsys).stdout.replace(" ", "")
     assert "[--foo](Default:True)" in stdout
     assert "[--no-foo](Default:False)" not in stdout
+
+
+@backends
+def test_show_default_string(backend, capsys):
+    @dataclass
+    class Command:
+        foo: Annotated[str, cappa.Arg(show_default="~{default}~")] = "asdf"
+
+    with pytest.raises(cappa.HelpExit):
+        parse(Command, "--help", backend=backend)
+
+    stdout = CapsysOutput.from_capsys(capsys).stdout.replace(" ", "")
+    assert "[FOO](Default:~asdf~)" in stdout
+
+
+@backends
+def test_show_default_explicit(backend, capsys):
+    @dataclass
+    class Command:
+        foo: Annotated[str, cappa.Arg(show_default=DefaultFormatter("!{default}!"))] = (
+            "asdf"
+        )
+
+    with pytest.raises(cappa.HelpExit):
+        parse(Command, "--help", backend=backend)
+
+    stdout = CapsysOutput.from_capsys(capsys).stdout.replace(" ", "")
+    assert "[FOO](Default:!asdf!)" in stdout


### PR DESCRIPTION
Fixes https://github.com/DanCardin/cappa/issues/184