### PR TITLE
fix: Ensure  args supply the correct parent context to the arg's action handler.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.26
 
+### 0.26.4
+- fix: Ensure `propagate=True` args supply the correct parent context to the arg's action handler.
+
 ### 0.26.3
 - fix: Reexport Empty/EmptyType types at the root.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cappa"
-version = "0.26.3"
+version = "0.26.4"
 description = "Declarative CLI argument parser."
 
 urls = { repository = "https://github.com/dancardin/cappa" }

--- a/uv.lock
+++ b/uv.lock
@@ -28,7 +28,7 @@ wheels = [
 
 [[package]]
 name = "cappa"
-version = "0.26.2"
+version = "0.26.3"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
Fixes https://github.com/DanCardin/cappa/issues/197