### PR TITLE
fix: Coerce `Env(default=None)` to `Empty` to avoid interpreting the value as a string.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,9 +74,9 @@ jobs:
         run: make test
 
       - name: Store test result artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          path: coverage.xml
+          path: coverage-${{ matrix.python-version }}-${{ matrix.pydantic-version }}.xml
 
       - uses: codecov/codecov-action@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.26
 
+### 0.26.5
+- fix: Coerce `Env(default=None)` to `Empty` to avoid interpreting the value as a string.
+
 ### 0.26.4
 - fix: Ensure `propagate=True` args supply the correct parent context to the arg's action handler.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cappa"
-version = "0.26.4"
+version = "0.26.5"
 description = "Declarative CLI argument parser."
 
 urls = { repository = "https://github.com/dancardin/cappa" }
@@ -19,16 +19,16 @@ docstring = ["docstring-parser >= 0.15"]
 
 [tool.uv]
 dev-dependencies = [
-  "pytest >=8.1.1,<9",
-  "coverage >= 7.3.0",
-  "mypy >= 1.0.0",
-  "ruff >= 0.6.2",
-  "docutils >= 0.20.0",
-  "types-docutils >= 0.20.0",
+    "pytest >=8.1.1,<9",
+    "coverage >= 7.3.0",
+    "mypy >= 1.0.0",
+    "ruff >= 0.6.2",
+    "docutils >= 0.20.0",
+    "types-docutils >= 0.20.0",
 
-  "attrs",
-  "pydantic",
-  "msgspec; python_version < '3.13'",
+    "attrs",
+    "pydantic",
+    "msgspec; python_version < '3.13'",
 ]
 
 [tool.ruff]
@@ -49,11 +49,11 @@ keep-runtime-typing = true
 show_missing = true
 skip_covered = true
 exclude_lines = [
-  "pragma: no cover",
-  "if TYPE_CHECKING:",
-  "if typing.TYPE_CHECKING:",
-  "if __name__ == .__main__.:",
-  "assert_never",
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "if typing.TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
+    "assert_never",
 ]
 
 [tool.coverage.run]

--- a/src/cappa/default.py
+++ b/src/cappa/default.py
@@ -112,6 +112,8 @@ class Env(DefaultType):
             if value is not None:
                 return value
 
+        if self.default is None:
+            return Empty
         return self.default
 
 

--- a/tests/arg/test_default_env_missing.py
+++ b/tests/arg/test_default_env_missing.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import patch
+
+from typing_extensions import Annotated
+
+import cappa
+from tests.utils import backends, parse
+
+
+@dataclass
+class Command:
+    opt: Annotated[str | None, cappa.Arg(default=cappa.Env("DOESNT_EXIST"))]
+    opt2: Annotated[
+        str | None, cappa.Arg(default=cappa.Env("DOESNT_EXIST", default=None))
+    ]
+    opt3: Annotated[
+        str | None, cappa.Arg(default=cappa.Env("DOESNT_EXIST", default=None))
+    ] = None
+
+
+@backends
+def test_env_missing(backend):
+    test = parse(Command, backend=backend)
+    assert test == Command(None, None, None)
+
+
+@backends
+def test_default_is_not_mapped(backend):
+    with patch("os.environ", new={"DOESNT_EXIST": "asdf"}):
+        test = parse(Command, backend=backend)
+
+    assert test == Command("asdf", "asdf", "asdf")

--- a/uv.lock
+++ b/uv.lock
@@ -28,7 +28,7 @@ wheels = [
 
 [[package]]
 name = "cappa"
-version = "0.26.3"
+version = "0.26.5"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
Fixes https://github.com/DanCardin/cappa/issues/199