### PR TITLE
fix: Handle multiple = in explicit arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.27
 
+### 0.27.1
+- fix: Handle multiple = in explicit arg.
+
 ### 0.27.0
 - feat: Add "Self" concept for invoke dependencies.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cappa"
-version = "0.27.0"
+version = "0.27.1"
 description = "Declarative CLI argument parser."
 
 urls = { repository = "https://github.com/dancardin/cappa" }
@@ -75,7 +75,7 @@ check_untyped_defs = true
 extend-ignore-re = [".*#.*typos: ignore[^\\n]*\\n"]
 
 [tool.typos.default.extend-identifiers]
- typ = "typ"
+typ = "typ"
 
 [tool.pytest.ini_options]
 doctest_optionflags = "NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ELLIPSIS"

--- a/src/cappa/parser.py
+++ b/src/cappa/parser.py
@@ -334,7 +334,7 @@ class RawOption:
         name = arg
         value = None
         if is_explicit:
-            name, value = arg.split("=")
+            name, value = arg.split("=", 1)
         return cls(name=name, is_long=is_long, value=value)
 
 

--- a/tests/parser/test_explicit_equal_option.py
+++ b/tests/parser/test_explicit_equal_option.py
@@ -24,4 +24,4 @@ def test_value_contains_equal(backend):
         value: Annotated[str, cappa.Arg(long=True)]
 
     result = parse(Args, "--value='var == val'", backend=backend)
-    assert result == Args(value="val='var == val'")
+    assert result == Args(value="'var == val'")

--- a/tests/parser/test_explicit_equal_option.py
+++ b/tests/parser/test_explicit_equal_option.py
@@ -17,6 +17,7 @@ def test_unrecognized_post_dash_arg(backend):
     result = parse(Args, "--value=val", backend=backend)
     assert result == Args(value="val")
 
+
 @backends
 def test_value_contains_equal(backend):
     @dataclass

--- a/tests/parser/test_explicit_equal_option.py
+++ b/tests/parser/test_explicit_equal_option.py
@@ -16,3 +16,12 @@ def test_unrecognized_post_dash_arg(backend):
 
     result = parse(Args, "--value=val", backend=backend)
     assert result == Args(value="val")
+
+@backends
+def test_value_contains_equal(backend):
+    @dataclass
+    class Args:
+        value: Annotated[str, cappa.Arg(long=True)]
+
+    result = parse(Args, "--value='var == val'", backend=backend)
+    assert result == Args(value="val='var == val'")


### PR DESCRIPTION
Currently, when an explicit arg contains `=` in the value (e.g. `--my-filter-arg='foo == bar'`) cappa will crash when attempting to parse the explicit arg as `arg.split('=')` returns more than the two expected values. This PR is a fix for that bug.