### PR TITLE
stricter type check on the examples directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ lint:
 	uv run --no-sync ruff check src tests examples || exit 1
 	uv run --no-sync --all-extras mypy src tests examples || exit 1
 	uv run --no-sync --all-extras pyright src tests examples || exit 1
+	uv run --no-sync --all-extras basedpyright examples -p examples/pyrightconfig.json || exit 1
 	uv run --no-sync ruff format --check src tests examples || exit 1
 
 lint-typos:

--- a/examples/pyrightconfig.json
+++ b/examples/pyrightconfig.json
@@ -1,0 +1,4 @@
+{
+    "typeCheckingMode": "strict",
+    "exclude": ["defer_import_slow_startup/defer_import/mean.py"],  // because of the pandas import
+}

--- a/examples/test_kitchen_sink/example.py
+++ b/examples/test_kitchen_sink/example.py
@@ -75,7 +75,7 @@ class BarkCommand: ...
 
 
 # invoke cli parsing
-def main(argv=None):
+def main(argv: list[str] | None = None):
     logging.basicConfig()
 
     args: Example = cappa.parse(Example, argv=argv, version="1.2.3")

--- a/examples/todo_list/todo.py
+++ b/examples/todo_list/todo.py
@@ -20,7 +20,7 @@ class AddCommand:
     def __call__(self):
         path = Path("todo.json")
 
-        data = []
+        data: list[str] = []
         if path.exists():
             data = json.loads(path.read_text())
 
@@ -34,7 +34,7 @@ class ListCommand:
     def __call__(self, output: cappa.Output):
         path = Path("todo.json")
 
-        data = []
+        data: list[str] = []
         if path.exists():
             data = json.loads(path.read_text())
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dev-dependencies = [
     "coverage >= 7.3.0",
     "mypy >= 1.0.0",
     "pyright >= 1.1.398",
+    "basedpyright >= 1.29.1",
     "ruff >= 0.9.0",
     "docutils >= 0.20.0",
     "types-docutils >= 0.20.0",

--- a/src/cappa/base.py
+++ b/src/cappa/base.py
@@ -25,6 +25,7 @@ if typing.TYPE_CHECKING:
     from cappa.arg import Arg
 
 T = typing.TypeVar("T")
+U = typing.TypeVar("U")
 
 
 def parse(
@@ -32,15 +33,15 @@ def parse(
     *,
     argv: list[str] | None = None,
     input: typing.TextIO | None = None,
-    backend: typing.Callable | None = None,
+    backend: typing.Callable[..., typing.Any] | None = None,
     color: bool = True,
-    version: str | Arg | None = None,
-    help: bool | Arg = True,
-    completion: bool | Arg = True,
+    version: str | Arg[typing.Any] | None = None,
+    help: bool | Arg[typing.Any] = True,
+    completion: bool | Arg[typing.Any] = True,
     theme: Theme | None = None,
     output: Output | None = None,
-    help_formatter: HelpFormattable | None = None,
-    state: State | None = None,
+    help_formatter: HelpFormattable[T] | None = None,
+    state: State[typing.Any] | None = None,
 ) -> T:
     """Parse the command, returning an instance of `obj`.
 
@@ -91,22 +92,22 @@ def parse(
 
 
 def invoke(
-    obj: type | Command,
+    obj: type | Command[typing.Any],
     *,
-    deps: typing.Sequence[typing.Callable]
-    | typing.Mapping[typing.Callable, Dep | typing.Any]
+    deps: typing.Sequence[typing.Callable[..., typing.Any]]
+    | typing.Mapping[typing.Callable[..., typing.Any], Dep[typing.Any] | typing.Any]
     | None = None,
     argv: list[str] | None = None,
     input: typing.TextIO | None = None,
-    backend: typing.Callable | None = None,
+    backend: typing.Callable[..., typing.Any] | None = None,
     color: bool = True,
-    version: str | Arg | None = None,
-    help: bool | Arg = True,
-    completion: bool | Arg = True,
+    version: str | Arg[typing.Any] | None = None,
+    help: bool | Arg[typing.Any] = True,
+    completion: bool | Arg[typing.Any] = True,
     theme: Theme | None = None,
     output: Output | None = None,
-    help_formatter: HelpFormattable | None = None,
-    state: State | None = None,
+    help_formatter: HelpFormattable[typing.Any] | None = None,
+    state: State[typing.Any] | None = None,
 ):
     """Parse the command, and invoke the selected async command or subcommand.
 
@@ -290,20 +291,63 @@ def parse_command(
     return command, parsed_command, instance, concrete_output, state
 
 
-@dataclass_transform()
+@typing.overload
 def command(
-    _cls=None,
+    _cls: type[T],
     *,
     name: str | None = None,
     help: str | None = None,
     description: str | None = None,
-    invoke: typing.Callable | str | None = None,
+    invoke: typing.Callable[..., typing.Any] | str | None = None,
     hidden: bool = False,
     default_short: bool = False,
     default_long: bool = False,
     deprecated: bool = False,
-    help_formatter: HelpFormattable = HelpFormatter.default,
-):
+    help_formatter: HelpFormattable[T] = HelpFormatter.default,
+) -> type[T]: ...
+@typing.overload
+def command(
+    *,
+    name: str | None = None,
+    help: str | None = None,
+    description: str | None = None,
+    invoke: typing.Callable[..., typing.Any] | str | None = None,
+    hidden: bool = False,
+    default_short: bool = False,
+    default_long: bool = False,
+    deprecated: bool = False,
+    help_formatter: HelpFormattable[T] = HelpFormatter.default,
+) -> typing.Callable[[type[T]], type[T]]: ...
+@typing.overload
+def command(
+    _cls: T,
+    *,
+    name: str | None = None,
+    help: str | None = None,
+    description: str | None = None,
+    invoke: typing.Callable[..., typing.Any] | str | None = None,
+    hidden: bool = False,
+    default_short: bool = False,
+    default_long: bool = False,
+    deprecated: bool = False,
+    help_formatter: HelpFormattable[T] = HelpFormatter.default,
+) -> T: ...
+
+
+@dataclass_transform()
+def command(
+    _cls: T | type[T] | None = None,
+    *,
+    name: str | None = None,
+    help: str | None = None,
+    description: str | None = None,
+    invoke: typing.Callable[..., typing.Any] | str | None = None,
+    hidden: bool = False,
+    default_short: bool = False,
+    default_long: bool = False,
+    deprecated: bool = False,
+    help_formatter: HelpFormattable[T] = HelpFormatter.default,
+) -> T | type[T] | typing.Callable[[type[T]], type[T]]:
     """Register a cappa CLI command/subcomment.
 
     Args:
@@ -330,7 +374,7 @@ def command(
         help_formatter: Override the default help formatter.
     """
 
-    def wrapper(_decorated_cls: T) -> T:
+    def wrapper(_decorated_cls: U) -> U:
         if inspect.isclass(_decorated_cls) and not detect(_decorated_cls):
             _decorated_cls = dataclasses.dataclass(_decorated_cls)  # type: ignore
 

--- a/src/cappa/help.py
+++ b/src/cappa/help.py
@@ -17,12 +17,12 @@ from cappa.default import Default, DefaultFormatter
 from cappa.output import Displayable
 from cappa.subcommand import Subcommand
 from cappa.type_view import Empty
-from cappa.typing import assert_type
+from cappa.typing import T, assert_type
 
 if typing.TYPE_CHECKING:
     from cappa.command import Command
 
-HelpFormattable: TypeAlias = typing.Callable[["Command", str], typing.List[Displayable]]
+HelpFormattable: TypeAlias = typing.Callable[["Command[T]", str], typing.List[Displayable]]
 ArgGroup: TypeAlias = typing.Tuple[
     typing.Tuple[str, bool], typing.List[typing.Union[Arg, Subcommand]]
 ]

--- a/src/cappa/output.py
+++ b/src/cappa/output.py
@@ -110,7 +110,7 @@ class Output:
             self.error(e, help=help, short_help=short_help)
 
     def output(
-        self, message: list[Displayable] | Displayable | Exit | str | None, **context
+        self, message: list[Displayable] | Displayable | Exit | str | None, **context: Displayable | list[Displayable] | None
     ):
         """Output a message to the `output_console`.
 


### PR DESCRIPTION
This does a more strict type check on just the `examples` directory
to help  make the public API able to be strict-checked - addressing https://github.com/DanCardin/cappa/issues/210
