### PR TITLE
Require rich 10.2.0 and typing-extensions 4.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,12 @@ classifiers = ["Topic :: Software Development :: Libraries :: Python Modules"]
 
 requires-python = ">=3.8,<4"
 
-dependencies = ["rich", "typing-extensions >= 4.8.0", "type-lens >= 0.2.3"]
+dependencies = [
+    "rich >= 10.2.0",
+    "typing-extensions >= 4.8.0",
+    "typing-extensions >= 4.12.0; python_version >= '3.13'",
+    "type-lens >= 0.2.3",
+]
 
 [project.optional-dependencies]
 docstring = ["docstring-parser >= 0.15"]


### PR DESCRIPTION
Hi,

First of all, thanks a lot for writing and maintaining cappa!

What do you think about this trivial change that bumps the dependency versions of `typing-extensions` and `rich` so that `import cappa` would work at all? :)

G'luck,
Peter
