### PR TITLE
fix: visual grouping of undocumented zsh completions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Unreleased: 0.29.0
 
+- fix: Undocumented completions.
 - docs: Add argument validation documentation.
 - feat: Test against python 3.14.
 - fix: Apply pyright strict typing.

--- a/src/cappa/completion/base.py
+++ b/src/cappa/completion/base.py
@@ -69,5 +69,5 @@ def format_completions(*completions: Completion | FileCompletion) -> str | None:
     result: list[str] = []
     for item in completions:
         item = cast(Completion, item)
-        result.append(f"{item.value}:{item.help if item.help else ''}")
+        result.append(f"{item.value}:{item.description}")
     return "\n".join(result)

--- a/src/cappa/completion/types.py
+++ b/src/cappa/completion/types.py
@@ -29,6 +29,14 @@ class ShellHandler:
 class Completion:
     value: str | None = None
     help: str | None = None
+    arg: Arg[Any] | None = None
+
+    @property
+    def description(self) -> str:
+        if not self.arg or self.arg.help:
+            return self.help or ""
+
+        return f"<{self.arg.value_name}> {self.help}".strip()
 
 
 @dataclasses.dataclass

--- a/tests/completion/test_option.py
+++ b/tests/completion/test_option.py
@@ -14,7 +14,7 @@ def test_long_option_name():
         default: bool = False
 
     result = parse_completion(Args, "--d")
-    assert result == "--default:"
+    assert result == "--default:<default> (Default: False)"
 
 
 def test_long_option_name_with_help():
@@ -23,7 +23,7 @@ def test_long_option_name_with_help():
         default: Annotated[bool, cappa.Arg(help="Enables default")] = False
 
     result = parse_completion(Args, "--d")
-    assert result == "--default:Enables default"
+    assert result == "--default:Enables default (Default: False)"
 
 
 def test_multiple_matches():
@@ -44,3 +44,12 @@ def test_short_name():
 
     result = parse_completion(Args, "-a")
     assert result is None
+
+
+def test_no_help_value_name():
+    @dataclass
+    class Args:
+        apple: Annotated[str, cappa.Arg(long=True)]
+
+    result = parse_completion(Args, "--a")
+    assert result == "--apple:<apple>"

--- a/tests/completion/test_subcommand.py
+++ b/tests/completion/test_subcommand.py
@@ -37,4 +37,4 @@ def test_subcommand_name_with_partial():
 def test_subcommand_args():
     result = parse_completion(Args, "bar", "--n")
     assert result
-    assert result == "--nested-opt:"
+    assert result == "--nested-opt:<nested_opt>"


### PR DESCRIPTION
fixes https://github.com/DanCardin/cappa/issues/219

* Includes the `<value_name>` of completions that dont have an explicit help to disambiguate them.
* Performs help formatting (to include choices/default) for completion. This was previously just the raw help text.

<img width="758" height="221" alt="Screenshot 2025-07-18 at 11 54 22 AM" src="https://github.com/user-attachments/assets/6c0f7519-4b9c-47e8-9fde-55fa90e1f222" />

Notice, it includes it for options that only have a default component (because it's not explicit help text) because it can end up trivially duplicated.