### PR TITLE
fix: Propagation of mutually exclusive options that map to the same `Arg.field_name`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - fix: Destructured relative context, e.g. counting.
 - fix: Add support for explicit type alias `Dep`s.
+- fix: Propagation of mutually exclusive options that map to the same `Arg.field_name`.
 
 ## 0.29.1
 

--- a/tests/arg/test_destructured_explicit.py
+++ b/tests/arg/test_destructured_explicit.py
@@ -28,6 +28,5 @@ class Args2:
     config: Annotated[Config, cappa.Arg(destructure=True)]
 
 
-def test_destructured_true():
-    test = parse(Args2, "--color=red")
-    assert test == Args2(config=Config(color="red"))
+test = parse(Args2, "--color=red")
+assert test == Args2(config=Config(color="red"))

--- a/tests/arg/test_propagate_mutual_exclusive_arg.py
+++ b/tests/arg/test_propagate_mutual_exclusive_arg.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from typing_extensions import Annotated
+
+import cappa
+from tests.utils import parse
+
+
+@dataclass
+class Args:
+    foo: Annotated[
+        bool,
+        cappa.Arg(
+            long=["--foo", "--no-foo"],
+            propagate=True,
+            default=False,
+            help="Enable or disable foo feature",
+        ),
+    ]
+    subcommand: cappa.Subcommands[Sub]
+
+
+@dataclass
+class Sub:
+    name: str
+
+
+def test_propagated_arg():
+    result = parse(Args, "--foo", "sub", "bar")
+    assert result == Args(foo=True, subcommand=Sub(name="bar"))
+
+    result = parse(Args, "--no-foo", "sub", "bar")
+    assert result == Args(foo=False, subcommand=Sub(name="bar"))
+
+    result = parse(Args, "sub", "--foo", "bar")
+    assert result == Args(foo=True, subcommand=Sub(name="bar"))
+
+    result = parse(Args, "sub", "--no-foo", "bar")
+    assert result == Args(foo=False, subcommand=Sub(name="bar"))


### PR DESCRIPTION
Fixes https://github.com/DanCardin/cappa/issues/233