### PR TITLE
feat: Apply default parsing automatically, with Arg.parse_inference == False to disable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.31.0
+- feat: Apply default parsing automatically, with Arg.parse_inference == False to disable.
+
 ## 0.30.4
 - fix: Use of a synchronous context manager inside an `invoke_async` invoke context.
 - fix: Stripped type aliases losing e.g. Dep metadata.

--- a/docs/source/arg.md
+++ b/docs/source/arg.md
@@ -527,9 +527,14 @@ Note cappa itself contains a number of component `parse_*` functions inside the 
 module, which can be used in combination with your own custom `parse` functions.
 ```
 
-### `default_parse`
+### `default_parse`/`Arg.parse_inference
 
-A function [cappa.default_parse](cappa.default_parse) is exposed
+A function [cappa.default_parse](cappa.default_parse) is exposed and **can** be directly referenced
+in parse function sequences. However by default the `default_parse` function is applied automatically
+at the end of the user-provided parse function/sequence.
+
+With that said, if the default behavior is undesirable, one can set `Arg(parse_inference=False)` to
+**only** execute the user provided parser function(s).
 
 (parsing-json)=
 ### Parsing JSON

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cappa"
-version = "0.30.4"
+version = "0.31.0"
 description = "Declarative CLI argument parser."
 
 urls = { repository = "https://github.com/dancardin/cappa" }

--- a/tests/arg/test_parse_inference.py
+++ b/tests/arg/test_parse_inference.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from typing_extensions import Annotated
+
+import cappa
+from tests.utils import Backend, backends, parse
+
+
+@dataclass
+class Args:
+    numbers: Annotated[str, cappa.Arg(parse=int, parse_inference=False)]
+
+
+@backends
+def test_disable_default_parser(backend: Backend):
+    test = parse(Args, "1", backend=backend)
+    assert test.numbers == 1

--- a/uv.lock
+++ b/uv.lock
@@ -84,7 +84,7 @@ wheels = [
 
 [[package]]
 name = "cappa"
-version = "0.30.3"
+version = "0.30.4"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
Addresses issue discovered in https://github.com/DanCardin/cappa/issues/248