### PR TITLE
feat: Add aliases= support for subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- feat: Add `aliases=` support for subcommands. Each entry is either a string (visible alias) or a `cappa.Alias(name, hidden=..., deprecated=...)` for finer control. Hidden aliases dispatch but are omitted from help and completion; deprecated aliases emit a runtime warning when used. Collisions are detected at construction time.
+
 ## 0.31.1
 - fix: Display Args with the same group identity as alternatives in helptext on the same line.
 - fix: Ensure automatic bool variants (--foo/--no-foo) are mutually exclusive.

--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -2,7 +2,7 @@
 
 ```{eval-rst}
 .. autoapimodule:: cappa
-   :members: parse, invoke, invoke_async, collect, command, Command, Subcommand, Dep, Arg, ArgAction, Exit, Env, Completion, Output, FileMode, unpack_arguments, Group, Prompt, Confirm, ValueFrom, Default, State, Self, default_parse
+   :members: parse, invoke, invoke_async, collect, command, Command, Subcommand, Alias, Dep, Arg, ArgAction, Exit, Env, Completion, Output, FileMode, unpack_arguments, Group, Prompt, Confirm, ValueFrom, Default, State, Self, default_parse
 ```
 
 ```{eval-rst}

--- a/docs/source/subcommand.md
+++ b/docs/source/subcommand.md
@@ -58,7 +58,130 @@ class SubcmdTwo:
   can decorate each subcommand class with `@cappa.command(name='<x>')` to choose
   your own name.
 
+## Aliases
+
+Subcommands can declare alternate names that invoke the same command. This is
+useful for short forms (`ls` for `list`), legacy spellings, and migration paths
+when renaming a command.
+
+Pass `aliases=` to `@cappa.command(...)`:
+
+```python
+import cappa
+from dataclasses import dataclass
+
+@cappa.command(aliases=["ls"])
+@dataclass
+class List:
+    pass
+
+@cappa.command(name="remove", aliases=["rm"])
+@dataclass
+class Remove:
+    pass
+
+@dataclass
+class Tool:
+    cmd: cappa.Subcommands[List | Remove]
+```
+
+With the above, `tool list`, `tool ls`, `tool remove`, and `tool rm` all work,
+and `--help` displays both names per subcommand:
+
+```
+Subcommands
+  list, ls
+  remove, rm
+```
+
+### Hidden aliases
+
+A bare string in `aliases=` produces a visible alias — it appears in `--help`
+output and shell completion. Use `cappa.Alias(name, hidden=True)` to accept the
+name without advertising it. This is handy for deprecated names you want to
+keep working without showing in the UI:
+
+```python
+@cappa.command(
+    aliases=[
+        "ls",                              # visible
+        cappa.Alias("dir", hidden=True),   # accepted, but absent from help
+    ],
+)
+@dataclass
+class List:
+    pass
+```
+
+### Deprecated aliases
+
+`cappa.Alias(name, deprecated=...)` emits a runtime warning to stderr when the
+user invokes the command via that alias, while still dispatching to the
+canonical command. Useful when you've renamed a subcommand but want to give
+users a transition period:
+
+```python
+@cappa.command(
+    name="remove",
+    aliases=[
+        cappa.Alias("rm", deprecated="use 'remove' instead"),
+        cappa.Alias("delete", deprecated=True),  # default message
+    ],
+)
+@dataclass
+class Remove:
+    pass
+```
+
+Invoking `tool rm` runs `Remove`, then prints:
+
+```
+Error: Command alias `rm` is deprecated: use 'remove' instead
+```
+
+`hidden` and `deprecated` compose — a hidden + deprecated alias is the typical
+shape for an old name you want to keep alive but never show again.
+
+### Imperative construction
+
+When constructing commands manually (without the decorator), `aliases=` is a
+keyword argument on `Command` itself:
+
+```python
+import cappa
+
+cmd = cappa.Command(
+    Tool,
+    arguments=[
+        cappa.Subcommand(
+            field_name="cmd",
+            options={
+                "list": cappa.Command(List, name="list", aliases=["ls"]),
+                "remove": cappa.Command(
+                    Remove, name="remove", aliases=["rm"]
+                ),
+            },
+        ),
+    ],
+)
+```
+
+The dict key in `Subcommand.options` remains the canonical name; aliases are
+declared on each `Command` and resolved automatically.
+
+### Collisions
+
+Aliases must not collide with another subcommand's canonical name, with another
+alias under the same parent, or with the command's own canonical name. Any of
+these raises `ValueError` at command construction time so the conflict is
+caught before the CLI ever runs.
+
 ```{eval-rst}
 .. autoapiclass:: cappa.Subcommand
+   :noindex:
+```
+
+```{eval-rst}
+.. autoapiclass:: cappa.Alias
    :noindex:
 ```

--- a/src/cappa/__init__.py
+++ b/src/cappa/__init__.py
@@ -1,5 +1,5 @@
 from cappa.base import collect, command, invoke, invoke_async, parse, parse_async
-from cappa.command import Command
+from cappa.command import Alias, Command
 from cappa.completion.types import Completion
 from cappa.default import Confirm, Default, Env, Prompt, ValueFrom
 from cappa.file_io import FileMode
@@ -20,6 +20,7 @@ from cappa import argparse
 from cappa.parser import backend
 
 __all__ = [
+    "Alias",
     "Arg",
     "ArgAction",
     "Command",

--- a/src/cappa/argparse.py
+++ b/src/cappa/argparse.py
@@ -288,18 +288,26 @@ def add_subcommands(
     dest_prefix: str = "",
 ):
     subcommand_dest = subcommands.field_name
+    typed_name_dest = f"{dest_prefix}{subcommand_dest}.__typed_name__"
+    visible_metavar = "{" + ",".join(subcommands.names()) + "}"
     subparsers = parser.add_subparsers(
         title=group,
         required=assert_type(subcommands.required, bool),
         parser_class=ArgumentParser,
+        dest=typed_name_dest,
+        metavar=visible_metavar,
     )
 
     for name, subcommand in subcommands.options.items():
         deprecated_kwarg = add_deprecated_kwarg(subcommand)
 
         nested_dest_prefix = f"{dest_prefix}{subcommand_dest}."
+        visible_aliases = [
+            a.name for a in subcommand.resolved_aliases() if not a.hidden
+        ]
         subparser = subparsers.add_parser(
             name=subcommand.real_name(),
+            aliases=visible_aliases,
             help=subcommand.help,
             description=subcommand.description,
             formatter_class=parser.formatter_class,
@@ -312,6 +320,13 @@ def add_subcommands(
         subparser.set_defaults(
             __command__=subcommand, **{nested_dest_prefix + "__name__": name}
         )
+
+        # Hidden aliases must dispatch to the same subparser without showing up
+        # in argparse's choices/help. We add them to the internal name map
+        # directly (post-construction so help has already been bound).
+        hidden_aliases = [a for a in subcommand.resolved_aliases() if a.hidden]
+        for alias in hidden_aliases:
+            subparsers._name_parser_map[alias.name] = subparser  # type: ignore[attr-defined]
 
         add_arguments(
             subparser,
@@ -338,6 +353,12 @@ def to_dict(value: argparse.Namespace):
     for k, v in value.__dict__.items():
         if isinstance(v, argparse.Namespace):
             v = to_dict(v)
+            # When `add_subparsers(dest=...)` was set but no subcommand was
+            # selected, argparse leaves the dest as None. In that case the
+            # subcommand wasn't invoked at all — drop it so downstream code
+            # doesn't think there's a result to dispatch.
+            if v == {"__typed_name__": None}:
+                continue
         result[k] = v
 
     return result

--- a/src/cappa/argparse.py
+++ b/src/cappa/argparse.py
@@ -5,7 +5,7 @@ import sys
 from typing import TYPE_CHECKING, Any, Callable, Hashable, List, TypeVar, cast
 
 from cappa.arg import Arg, ArgAction, Group
-from cappa.command import Command, Subcommand
+from cappa.command import Alias, Command, Subcommand
 from cappa.help import ArgGroup
 from cappa.invoke.base import fulfill_deps
 from cappa.output import Exit, HelpExit, Output
@@ -288,13 +288,11 @@ def add_subcommands(
     dest_prefix: str = "",
 ):
     subcommand_dest = subcommands.field_name
-    typed_name_dest = f"{dest_prefix}{subcommand_dest}.__typed_name__"
     visible_metavar = "{" + ",".join(subcommands.names()) + "}"
     subparsers = parser.add_subparsers(
         title=group,
         required=assert_type(subcommands.required, bool),
         parser_class=ArgumentParser,
-        dest=typed_name_dest,
         metavar=visible_metavar,
     )
 
@@ -302,12 +300,14 @@ def add_subcommands(
         deprecated_kwarg = add_deprecated_kwarg(subcommand)
 
         nested_dest_prefix = f"{dest_prefix}{subcommand_dest}."
-        visible_aliases = [
-            a.name for a in subcommand.resolved_aliases() if not a.hidden
+        non_deprecated_visible_aliases = [
+            a.name
+            for a in subcommand.resolved_aliases()
+            if not a.hidden and not a.deprecated
         ]
         subparser = subparsers.add_parser(
             name=subcommand.real_name(),
-            aliases=visible_aliases,
+            aliases=non_deprecated_visible_aliases,
             help=subcommand.help,
             description=subcommand.description,
             formatter_class=parser.formatter_class,
@@ -321,12 +321,18 @@ def add_subcommands(
             __command__=subcommand, **{nested_dest_prefix + "__name__": name}
         )
 
-        # Hidden aliases must dispatch to the same subparser without showing up
-        # in argparse's choices/help. We add them to the internal name map
-        # directly (post-construction so help has already been bound).
-        hidden_aliases = [a for a in subcommand.resolved_aliases() if a.hidden]
-        for alias in hidden_aliases:
-            subparsers._name_parser_map[alias.name] = subparser
+        # Aliases not registered via `aliases=` (hidden, or deprecated) get spliced
+        # into the internal name map. Deprecated aliases get a wrapper that emits
+        # the warning at dispatch time, then delegates parsing to the real subparser.
+        for alias in subcommand.resolved_aliases():
+            if alias.name in non_deprecated_visible_aliases:
+                continue
+            if alias.deprecated:
+                subparsers._name_parser_map[alias.name] = _DeprecatedAliasParser(
+                    subparser, alias, output
+                )
+            else:
+                subparsers._name_parser_map[alias.name] = subparser
 
         add_arguments(
             subparser,
@@ -348,17 +354,43 @@ def backend_num_args(num_args: int | None, required: bool) -> int | str | None:
     return num_args
 
 
+class _DeprecatedAliasParser(ArgumentParser):
+    """Stand-in subparser used when a user invokes a deprecated alias.
+
+    argparse dispatches into here via `_name_parser_map[alias_name]`. We emit
+    the deprecation warning, then delegate parsing to the real subparser so the
+    canonical `__name__` and arguments are populated as usual.
+    """
+
+    def __init__(
+        self, real_parser: ArgumentParser, alias: Alias, output: Output
+    ) -> None:
+        super().__init__(
+            command=real_parser.command,
+            output=output,
+            add_help=False,
+            allow_abbrev=False,
+        )
+        self._real_parser = real_parser
+        self._alias = alias
+
+    def parse_known_args(  # type: ignore[override]
+        self,
+        args: Any = None,
+        namespace: Any = None,
+    ) -> tuple[argparse.Namespace, list[str]]:
+        message = f"Command alias `{self._alias.name}` is deprecated"
+        if isinstance(self._alias.deprecated, str):
+            message += f": {self._alias.deprecated}"
+        self.output.error(message)
+        return self._real_parser.parse_known_args(args, namespace)
+
+
 def to_dict(value: argparse.Namespace):
     result: dict[str, Any] = {}
     for k, v in value.__dict__.items():
         if isinstance(v, argparse.Namespace):
             v = to_dict(v)
-            # When `add_subparsers(dest=...)` was set but no subcommand was
-            # selected, argparse leaves the dest as None. In that case the
-            # subcommand wasn't invoked at all — drop it so downstream code
-            # doesn't think there's a result to dispatch.
-            if v == {"__typed_name__": None}:
-                continue
         result[k] = v
 
     return result

--- a/src/cappa/argparse.py
+++ b/src/cappa/argparse.py
@@ -326,7 +326,7 @@ def add_subcommands(
         # directly (post-construction so help has already been bound).
         hidden_aliases = [a for a in subcommand.resolved_aliases() if a.hidden]
         for alias in hidden_aliases:
-            subparsers._name_parser_map[alias.name] = subparser  # type: ignore[attr-defined]
+            subparsers._name_parser_map[alias.name] = subparser
 
         add_arguments(
             subparser,

--- a/src/cappa/base.py
+++ b/src/cappa/base.py
@@ -17,7 +17,7 @@ from typing_extensions import dataclass_transform
 
 from cappa import argparse, parser
 from cappa.class_inspect import detect
-from cappa.command import Command
+from cappa.command import Alias, Command
 from cappa.help import HelpFormattable, HelpFormatter
 from cappa.invoke.base import resolve_callable
 from cappa.invoke.types import DepTypes, InvokeCallableSpec
@@ -495,6 +495,7 @@ def command(
     _cls: type[T],
     *,
     name: str | None = None,
+    aliases: list[str | Alias] | None = None,
     help: str | None = None,
     description: str | None = None,
     invoke: InvokeCallableSpec[Any] | None = None,
@@ -508,6 +509,7 @@ def command(
 def command(
     *,
     name: str | None = None,
+    aliases: list[str | Alias] | None = None,
     help: str | None = None,
     description: str | None = None,
     invoke: InvokeCallableSpec[Any] | None = None,
@@ -522,6 +524,7 @@ def command(
     _cls: T,
     *,
     name: str | None = None,
+    aliases: list[str | Alias] | None = None,
     help: str | None = None,
     description: str | None = None,
     invoke: InvokeCallableSpec[Any] | None = None,
@@ -538,6 +541,7 @@ def command(
     _cls: type[T] | T | None = None,
     *,
     name: str | None = None,
+    aliases: list[str | Alias] | None = None,
     help: str | None = None,
     description: str | None = None,
     invoke: InvokeCallableSpec[Any] | None = None,
@@ -552,6 +556,11 @@ def command(
     Args:
         name: The name of the command. If omitted, the name of the command
             will be the name of the `cls`, converted to dash-case.
+        aliases: Alternate names that may be used to invoke this command as a
+            subcommand. Each entry is either a plain string (visible alias) or
+            an :class:`Alias` instance (which can be marked `hidden=True` or
+            `deprecated=...`). Only meaningful when the class is used as a
+            subcommand.
         help: Optional help text. If omitted, the `cls` docstring will be parsed,
             and the headline section will be used to document the command
             itself, and the arguments section will become the default help text for
@@ -582,6 +591,7 @@ def command(
             command,
             invoke=invoke,
             name=name,
+            aliases=list(aliases) if aliases is not None else command.aliases,
             help=help,
             description=description,
             hidden=hidden,

--- a/src/cappa/command.py
+++ b/src/cappa/command.py
@@ -42,10 +42,36 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
+@dataclasses.dataclass(frozen=True)
+class Alias:
+    """Describe an alternate name for a subcommand.
+
+    Arguments:
+        name: The alternate name a user may type to invoke the subcommand.
+        hidden: If `True`, the alias is accepted but omitted from help output and
+            from shell completion. Useful for supporting old names without
+            advertising them.
+        deprecated: If supplied, invoking the subcommand via this alias will emit
+            a deprecation warning. If `True`, a default message is used; a string
+            value is used as the deprecation message verbatim.
+    """
+
+    name: str
+    hidden: bool = False
+    deprecated: bool | str = False
+
+    @classmethod
+    def coerce(cls, value: str | Alias) -> Alias:
+        if isinstance(value, Alias):
+            return value
+        return cls(name=value)
+
+
 class CommandArgs(TypedDict, total=False):
     cmd_cls: type
     arguments: list[Arg[Any] | Subcommand]
     name: str | None
+    aliases: list[str | Alias]
     help: str | None
     description: str | None
     invoke: Callable[..., Any] | str | None
@@ -93,6 +119,7 @@ class Command(Generic[T]):
     propagated_arguments: list[Arg[Any]] = dataclasses.field(default_factory=lambda: [])
 
     name: str | None = None
+    aliases: list[str | Alias] = dataclasses.field(default_factory=lambda: [])
     help: str | None = None
     description: str | None = None
     invoke: Callable[..., Any] | str | None = None
@@ -136,6 +163,9 @@ class Command(Generic[T]):
 
         cls_name = self.cmd_cls.__name__
         return re.sub(r"(?<!^)(?=[A-Z])", "-", cls_name).lower()
+
+    def resolved_aliases(self) -> list[Alias]:
+        return [Alias.coerce(a) for a in self.aliases]
 
     @classmethod
     def collect(

--- a/src/cappa/help.py
+++ b/src/cappa/help.py
@@ -207,8 +207,11 @@ def add_long_args(
 
             else:
                 assert field_group.subcommand
-                for option in field_group.subcommand.available_options():
-                    table.add_row(*format_subcommand(help_formatter, option))
+                subcommand = field_group.subcommand
+                for option in subcommand.available_options():
+                    table.add_row(
+                        *format_subcommand(help_formatter, option, subcommand)
+                    )
 
         table.add_row()
 
@@ -323,12 +326,21 @@ def _replace_rich_text_component(c: TextComponent, text: str) -> TextComponent:
     return text
 
 
-def format_subcommand(help_formatter: HelpFormatter, command: Command[Any]):
+def format_subcommand(
+    help_formatter: HelpFormatter,
+    command: Command[Any],
+    subcommand: Subcommand | None = None,
+):
+    canonical = command.real_name()
+    parts = [f"[cappa.subcommand]{canonical}[/cappa.subcommand]"]
+    if subcommand is not None:
+        for alias in subcommand.visible_aliases_for(canonical):
+            label = alias.name
+            if alias.deprecated:
+                label = f"{label} (deprecated)"
+            parts.append(f"[cappa.subcommand]{label}[/cappa.subcommand]")
     return (
-        Padding(
-            f"[cappa.subcommand]{command.real_name()}[/cappa.subcommand]",
-            help_formatter.left_padding,
-        ),
+        Padding(", ".join(parts), help_formatter.left_padding),
         command.help,
     )
 

--- a/src/cappa/parser.py
+++ b/src/cappa/parser.py
@@ -16,7 +16,7 @@ from typing import (
 )
 
 from cappa.arg import Arg, ArgAction, ArgActionType, Group
-from cappa.command import Command, Subcommand
+from cappa.command import Alias, Command, Subcommand
 from cappa.completion.types import Completion, FileCompletion
 from cappa.help import format_args, format_subcommand_names
 from cappa.invoke.base import fulfill_deps
@@ -541,10 +541,12 @@ def consume_subcommand(
     command = arg.options[canonical]
     check_deprecated(parse_state, command)
 
+    if value.raw != canonical:
+        _, alias = arg.alias_map[value.raw]
+        _warn_deprecated_alias(parse_state, alias)
+
     parse_state.push_command(command)
     nested_context = context.push(command, canonical)
-    if value.raw != canonical:
-        nested_context.result["__typed_name__"] = value.raw
 
     parse(parse_state, nested_context)
 
@@ -759,6 +761,17 @@ def check_deprecated(
     message = f"{kind} `{name}` is deprecated"
     if isinstance(arg.deprecated, str):
         message += f": {arg.deprecated}"
+
+    parse_state.output.error(message)
+
+
+def _warn_deprecated_alias(parse_state: ParseState, alias: Alias) -> None:
+    if not alias.deprecated:
+        return
+
+    message = f"Command alias `{alias.name}` is deprecated"
+    if isinstance(alias.deprecated, str):
+        message += f": {alias.deprecated}"
 
     parse_state.output.error(message)
 

--- a/src/cappa/parser.py
+++ b/src/cappa/parser.py
@@ -522,9 +522,12 @@ def consume_subcommand(
         )
 
     assert isinstance(value, RawArg), value
-    if value.raw not in arg.options:
+    canonical = arg.resolve_name(value.raw)
+    if canonical is None:
         message = f"Invalid command '{value.raw}'"
-        possible_values = [name for name in arg.names() if name.startswith(value.raw)]
+        possible_values = [
+            name for name in arg.all_visible_names() if name.startswith(value.raw)
+        ]
         if possible_values:
             message += f" (Did you mean: {format_subcommand_names(possible_values)})"
 
@@ -535,11 +538,13 @@ def consume_subcommand(
             arg=arg,
         )
 
-    command = arg.options[value.raw]
+    command = arg.options[canonical]
     check_deprecated(parse_state, command)
 
     parse_state.push_command(command)
-    nested_context = context.push(command, value.raw)
+    nested_context = context.push(command, canonical)
+    if value.raw != canonical:
+        nested_context.result["__typed_name__"] = value.raw
 
     parse(parse_state, nested_context)
 

--- a/src/cappa/subcommand.py
+++ b/src/cappa/subcommand.py
@@ -125,25 +125,11 @@ class Subcommand:
         state: State[Any] | None = None,
         input: TextIO | None = None,
     ) -> tuple[Resolved[Any], dict[Any, Any]]:
-        option_name = parsed_args.pop("__name__")
-        typed_name = parsed_args.pop("__typed_name__", None)
-        canonical = self.resolve_name(option_name) or option_name
-        if typed_name is not None and typed_name != canonical:
-            self._warn_deprecated_alias(output, typed_name)
+        canonical = parsed_args.pop("__name__")
         option = self.options[canonical]
         return option.map_result(
             option, prog, parsed_args, output=output, state=state, input=input
         )
-
-    def _warn_deprecated_alias(self, output: Output, typed_name: str) -> None:
-        _, alias = self.alias_map[typed_name]
-        if not alias.deprecated:
-            return
-
-        message = f"Command alias `{typed_name}` is deprecated"
-        if isinstance(alias.deprecated, str):
-            message += f": {alias.deprecated}"
-        output.error(message)
 
     def available_options(self) -> list[Command[Any]]:
         return [o for o in self.options.values() if not o.hidden]

--- a/src/cappa/subcommand.py
+++ b/src/cappa/subcommand.py
@@ -136,10 +136,7 @@ class Subcommand:
         )
 
     def _warn_deprecated_alias(self, output: Output, typed_name: str) -> None:
-        entry = self.alias_map.get(typed_name)
-        if entry is None:
-            return
-        _, alias = entry
+        _, alias = self.alias_map[typed_name]
         if not alias.deprecated:
             return
 

--- a/src/cappa/subcommand.py
+++ b/src/cappa/subcommand.py
@@ -15,7 +15,7 @@ from cappa.typing import T, assert_type, find_annotations
 
 if TYPE_CHECKING:
     from cappa.arg import Arg
-    from cappa.command import Command
+    from cappa.command import Alias, Command
     from cappa.help import HelpFormattable
     from cappa.output import Output
 
@@ -50,6 +50,12 @@ class Subcommand:
 
     options: dict[str, Command[Any]] = dataclasses.field(default_factory=lambda: {})
     types: Iterable[type] | EmptyType = Empty
+
+    # Mapping of alias name -> (canonical name in `options`, Alias metadata).
+    # Populated during `normalize` from each Command's `aliases` field; collisions raise.
+    alias_map: dict[str, tuple[str, Alias]] = dataclasses.field(
+        default_factory=lambda: {}
+    )
 
     @classmethod
     def detect(cls, field: Field, type_view: TypeView[Any]) -> Subcommand | None:
@@ -86,6 +92,7 @@ class Subcommand:
             propagated_arguments=propagated_arguments,
             state=state,
         )
+        alias_map = build_alias_map(options)
         group = infer_group(self)
 
         return dataclasses.replace(
@@ -94,8 +101,20 @@ class Subcommand:
             types=types,
             required=required,
             options=options,
+            alias_map=alias_map,
             group=group,
         )
+
+    def resolve_name(self, name: str) -> str | None:
+        """Return the canonical name for a typed-in name (canonical or alias).
+
+        Returns `None` when `name` matches neither.
+        """
+        if name in self.options:
+            return name
+        if name in self.alias_map:
+            return self.alias_map[name][0]
+        return None
 
     def map_result(
         self,
@@ -107,10 +126,27 @@ class Subcommand:
         input: TextIO | None = None,
     ) -> tuple[Resolved[Any], dict[Any, Any]]:
         option_name = parsed_args.pop("__name__")
-        option = self.options[option_name]
+        typed_name = parsed_args.pop("__typed_name__", None)
+        canonical = self.resolve_name(option_name) or option_name
+        if typed_name is not None and typed_name != canonical:
+            self._warn_deprecated_alias(output, typed_name)
+        option = self.options[canonical]
         return option.map_result(
             option, prog, parsed_args, output=output, state=state, input=input
         )
+
+    def _warn_deprecated_alias(self, output: Output, typed_name: str) -> None:
+        entry = self.alias_map.get(typed_name)
+        if entry is None:
+            return
+        _, alias = entry
+        if not alias.deprecated:
+            return
+
+        message = f"Command alias `{typed_name}` is deprecated"
+        if isinstance(alias.deprecated, str):
+            message += f": {alias.deprecated}"
+        output.error(message)
 
     def available_options(self) -> list[Command[Any]]:
         return [o for o in self.options.values() if not o.hidden]
@@ -118,11 +154,27 @@ class Subcommand:
     def names(self) -> list[str]:
         return [n for n, o in self.options.items() if not o.hidden]
 
+    def visible_aliases_for(self, canonical: str) -> list[Alias]:
+        """Visible (non-hidden) aliases for the given canonical subcommand name."""
+        command = self.options.get(canonical)
+        if command is None:
+            return []
+        return [a for a in command.resolved_aliases() if not a.hidden]
+
+    def all_visible_names(self) -> list[str]:
+        """Canonical names plus visible aliases, in declaration order."""
+        result: list[str] = []
+        for name in self.names():
+            result.append(name)
+            for alias in self.visible_aliases_for(name):
+                result.append(alias.name)
+        return result
+
     def names_str(self, delimiter: str = ", ") -> str:
         return f"{delimiter.join(self.names())}"
 
     def completion(self, partial: str):
-        return [Completion(o) for o in self.options if partial in o]
+        return [Completion(o) for o in self.all_visible_names() if partial in o]
 
 
 def infer_types(arg: Subcommand, type_view: TypeView[Any]) -> Iterable[type]:
@@ -170,6 +222,37 @@ def infer_options(
         )
 
     return options
+
+
+def build_alias_map(
+    options: dict[str, Command[Any]],
+) -> dict[str, tuple[str, Alias]]:
+    """Build alias name -> (canonical, Alias) for a set of subcommand options.
+
+    Raises `ValueError` on collisions: an alias matching another command's
+    canonical name, an alias colliding with another alias, or an alias that
+    duplicates its own canonical name.
+    """
+    alias_map: dict[str, tuple[str, Alias]] = {}
+    for canonical, command in options.items():
+        for alias in command.resolved_aliases():
+            if alias.name == canonical:
+                raise ValueError(
+                    f"Subcommand '{canonical}' has an alias matching its own name."
+                )
+            if alias.name in options:
+                raise ValueError(
+                    f"Subcommand alias '{alias.name}' (for '{canonical}') "
+                    f"collides with another subcommand's name."
+                )
+            if alias.name in alias_map:
+                other_canonical, _ = alias_map[alias.name]
+                raise ValueError(
+                    f"Subcommand alias '{alias.name}' is declared on both "
+                    f"'{other_canonical}' and '{canonical}'."
+                )
+            alias_map[alias.name] = (canonical, alias)
+    return alias_map
 
 
 def infer_group(arg: Subcommand) -> Group:

--- a/tests/subcommand/test_aliases.py
+++ b/tests/subcommand/test_aliases.py
@@ -59,6 +59,28 @@ def test_canonical_does_not_warn(backend: Backend, capsys: Any):
     assert "deprecated" not in err
 
 
+@cappa.command(aliases=[cappa.Alias("del", deprecated=True)])
+@dataclass
+class DeleteBool:
+    pass
+
+
+@dataclass
+class DeleteBoolRoot:
+    cmd: cappa.Subcommands[DeleteBool]
+
+
+@backends
+def test_deprecated_alias_bool_warns_without_suffix(backend: Backend, capsys: Any):
+    """`deprecated=True` (bool) emits the default message with no `:` suffix."""
+    result = parse(DeleteBoolRoot, "del", backend=backend)
+    assert isinstance(result.cmd, DeleteBool)
+
+    err = capsys.readouterr().err
+    assert "Command alias `del` is deprecated" in err
+    assert "Command alias `del` is deprecated:" not in err
+
+
 # --- Hidden alias ---
 
 
@@ -218,3 +240,34 @@ class CollideABRoot:
 def test_alias_collides_with_other_alias():
     with pytest.raises(ValueError, match="declared on both"):
         cappa.collect(CollideABRoot)
+
+
+# --- Defensive helpers (direct unit calls) ---
+
+
+def test_visible_aliases_for_unknown_canonical_returns_empty():
+    """`visible_aliases_for` returns [] when given a name that isn't a subcommand."""
+    sub = cappa.Subcommand(field_name="cmd", options={})
+    assert sub.visible_aliases_for("not-a-subcommand") == []
+
+
+def test_warn_deprecated_alias_no_op_for_unknown_name(capsys: Any):
+    """`_warn_deprecated_alias` is a no-op when the typed name isn't an alias."""
+    from cappa.output import Output
+
+    sub = cappa.Subcommand(field_name="cmd", options={})
+    sub._warn_deprecated_alias(Output(), "ghost-alias")
+    err = capsys.readouterr().err
+    assert err == ""
+
+
+def test_format_subcommand_without_subcommand_arg():
+    """`format_subcommand` works with the default `subcommand=None`."""
+    from cappa.help import HelpFormatter, format_subcommand
+
+    cmd = cappa.Command(List)
+    padding, help_text = format_subcommand(HelpFormatter(), cmd)
+    rendered = str(padding.renderable)
+    assert "list" in rendered
+    assert "ls" not in rendered  # aliases only appear when subcommand is provided
+    assert help_text == cmd.help

--- a/tests/subcommand/test_aliases.py
+++ b/tests/subcommand/test_aliases.py
@@ -251,16 +251,6 @@ def test_visible_aliases_for_unknown_canonical_returns_empty():
     assert sub.visible_aliases_for("not-a-subcommand") == []
 
 
-def test_warn_deprecated_alias_no_op_for_unknown_name(capsys: Any):
-    """`_warn_deprecated_alias` is a no-op when the typed name isn't an alias."""
-    from cappa.output import Output
-
-    sub = cappa.Subcommand(field_name="cmd", options={})
-    sub._warn_deprecated_alias(Output(), "ghost-alias")
-    err = capsys.readouterr().err
-    assert err == ""
-
-
 def test_format_subcommand_without_subcommand_arg():
     """`format_subcommand` works with the default `subcommand=None`."""
     from cappa.help import HelpFormatter, format_subcommand

--- a/tests/subcommand/test_aliases.py
+++ b/tests/subcommand/test_aliases.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Union
+
+import pytest
+
+import cappa
+from tests.utils import Backend, backends, parse, parse_completion
+
+
+@cappa.command(aliases=["ls"])
+@dataclass
+class List:
+    pass
+
+
+@cappa.command(
+    aliases=[cappa.Alias("rm", deprecated="use remove")],
+)
+@dataclass
+class Remove:
+    pass
+
+
+@dataclass
+class Tool:
+    cmd: cappa.Subcommands[Union[List, Remove]]
+
+
+@backends
+def test_visible_alias_dispatches(backend: Backend):
+    result = parse(Tool, "list", backend=backend)
+    assert isinstance(result.cmd, List)
+
+    result = parse(Tool, "ls", backend=backend)
+    assert isinstance(result.cmd, List)
+
+
+@backends
+def test_canonical_still_dispatches(backend: Backend):
+    result = parse(Tool, "remove", backend=backend)
+    assert isinstance(result.cmd, Remove)
+
+
+@backends
+def test_deprecated_alias_warns(backend: Backend, capsys: Any):
+    result = parse(Tool, "rm", backend=backend)
+    assert isinstance(result.cmd, Remove)
+
+    err = capsys.readouterr().err
+    assert "Command alias `rm` is deprecated: use remove" in err
+
+
+@backends
+def test_canonical_does_not_warn(backend: Backend, capsys: Any):
+    parse(Tool, "remove", backend=backend)
+    err = capsys.readouterr().err
+    assert "deprecated" not in err
+
+
+# --- Hidden alias ---
+
+
+@cappa.command(aliases=[cappa.Alias("dir", hidden=True)])
+@dataclass
+class HiddenList:
+    pass
+
+
+@dataclass
+class HiddenTool:
+    cmd: cappa.Subcommands[HiddenList]
+
+
+@backends
+def test_hidden_alias_dispatches(backend: Backend):
+    result = parse(HiddenTool, "dir", backend=backend)
+    assert isinstance(result.cmd, HiddenList)
+
+
+@backends
+def test_hidden_alias_not_in_help(backend: Backend, capsys: Any):
+    with pytest.raises(cappa.Exit):
+        parse(HiddenTool, "--help", backend=backend)
+
+    out = capsys.readouterr().out
+    assert "dir" not in out
+    assert "hidden-list" in out
+
+
+# --- Completion ---
+
+
+def test_completion_includes_visible_alias():
+    result = parse_completion(Tool, "")
+    assert result is not None
+    assert "list" in result
+    assert "ls" in result
+    assert "remove" in result
+    assert "rm" in result
+
+
+def test_completion_excludes_hidden_alias():
+    result = parse_completion(HiddenTool, "")
+    assert result is not None
+    assert "hidden-list" in result
+    assert "dir" not in result
+
+
+# --- Help rendering ---
+
+
+@backends
+def test_visible_aliases_in_help(backend: Backend, capsys: Any):
+    with pytest.raises(cappa.Exit):
+        parse(Tool, "--help", backend=backend)
+
+    out = capsys.readouterr().out
+    assert "list, ls" in out
+    assert "remove, rm (deprecated)" in out
+
+
+# --- Imperative construction ---
+
+
+@dataclass
+class ImpA:
+    pass
+
+
+@dataclass
+class ImpB:
+    pass
+
+
+@backends
+def test_imperative_aliases(backend: Backend):
+    """Aliases declared on Command directly (not via decorator) work the same way."""
+    sub = cappa.Subcommand(
+        field_name="cmd",
+        options={
+            "imp-a": cappa.Command(ImpA, name="imp-a", aliases=["a"]),
+            "imp-b": cappa.Command(ImpB, name="imp-b", aliases=["b"]),
+        },
+    )
+
+    @dataclass
+    class ImpRoot:
+        cmd: cappa.Subcommands[Union[ImpA, ImpB]]
+
+    cmd = cappa.Command(ImpRoot, arguments=[sub])
+    result = parse(cmd, "a", backend=backend)
+    assert isinstance(result.cmd, ImpA)
+
+    result = parse(cmd, "b", backend=backend)
+    assert isinstance(result.cmd, ImpB)
+
+
+# --- Collisions ---
+
+
+@cappa.command(aliases=["self-collide"])
+@dataclass
+class SelfCollide:
+    pass
+
+
+@dataclass
+class SelfCollideRoot:
+    cmd: cappa.Subcommands[SelfCollide]
+
+
+def test_alias_collides_with_own_canonical_name():
+    with pytest.raises(ValueError, match="matching its own name"):
+        cappa.collect(SelfCollideRoot)
+
+
+@cappa.command(name="collide-x")
+@dataclass
+class CollideX:
+    pass
+
+
+@cappa.command(aliases=["collide-x"])
+@dataclass
+class CollideY:
+    pass
+
+
+@dataclass
+class CollideXYRoot:
+    cmd: cappa.Subcommands[Union[CollideX, CollideY]]
+
+
+def test_alias_collides_with_other_canonical_name():
+    with pytest.raises(ValueError, match="collides with another subcommand"):
+        cappa.collect(CollideXYRoot)
+
+
+@cappa.command(aliases=["shared"])
+@dataclass
+class CollideA:
+    pass
+
+
+@cappa.command(aliases=["shared"])
+@dataclass
+class CollideB:
+    pass
+
+
+@dataclass
+class CollideABRoot:
+    cmd: cappa.Subcommands[Union[CollideA, CollideB]]
+
+
+def test_alias_collides_with_other_alias():
+    with pytest.raises(ValueError, match="declared on both"):
+        cappa.collect(CollideABRoot)


### PR DESCRIPTION
## Summary

Adds first-class support for subcommand aliases. `@cappa.command(aliases=...)` accepts either plain strings (visible aliases) or `cappa.Alias(name, hidden=..., deprecated=...)` for richer control:

- **Visible aliases** — appear in `--help` (`list, ls`) and shell completion.
- **Hidden aliases** — `Alias("dir", hidden=True)` dispatches but is omitted from help/completion.
- **Deprecated aliases** — `Alias("rm", deprecated="use 'remove'")` emits a runtime warning when used; can be combined with `hidden=True`.
- **Collisions** (self / alias-vs-canonical / alias-vs-alias) raise `ValueError` at command construction time.
- Works with both the native cappa parser and the argparse backend, and with imperative `Command(..., aliases=...)` construction.

See `docs/source/subcommand.md` for usage examples and `tests/subcommand/test_aliases.py` for the full behavior matrix.

## Test plan

- [x] `pytest tests/subcommand/test_aliases.py` — 21 cases pass on both backends
- [x] `pytest tests/` — full suite green except 6 pre-existing `test_docstring.py` failures unrelated to this change
- [x] `sphinx-build` — docs build with no new warnings