### PR TITLE
refactor: Add "final" variants of Arg/Command/Subcommand.

### DIFF
--- a/src/cappa/__init__.py
+++ b/src/cappa/__init__.py
@@ -1,5 +1,5 @@
 from cappa.base import collect, command, invoke, invoke_async, parse, parse_async
-from cappa.command import Alias, Command
+from cappa.command import Alias, Command, FinalCommand
 from cappa.completion.types import Completion
 from cappa.default import Confirm, Default, Env, Prompt, ValueFrom
 from cappa.file_io import FileMode
@@ -8,11 +8,11 @@ from cappa.invoke.types import Dep, Self
 from cappa.output import Exit, HelpExit, Output
 from cappa.parse import default_parse, unpack_arguments
 from cappa.state import State
-from cappa.subcommand import Subcommand, Subcommands
+from cappa.subcommand import FinalSubcommand, Subcommand, Subcommands
 from cappa.type_view import Empty, EmptyType
 
 # isort: split
-from cappa.arg import Arg, ArgAction, Group, NumArgs
+from cappa.arg import Arg, ArgAction, FinalArg, Group, NumArgs
 from cappa.destructure import Destructured
 
 # isort: split
@@ -34,6 +34,9 @@ __all__ = [
     "Env",
     "Exit",
     "FileMode",
+    "FinalArg",
+    "FinalCommand",
+    "FinalSubcommand",
     "Group",
     "HelpExit",
     "HelpFormattable",

--- a/src/cappa/arg.py
+++ b/src/cappa/arg.py
@@ -11,7 +11,6 @@ from typing import (
     Callable,
     Generic,
     Iterable,
-    List,
     Literal,
     Sequence,
     Set,
@@ -32,7 +31,6 @@ from cappa.typing import (
     Doc,
     DocType,
     T,
-    assert_type,
     detect_choices,
     find_annotations,
 )
@@ -388,7 +386,7 @@ class Arg(Generic[T]):
     short: bool | str | list[str] | None = False
     long: bool | str | list[str] | None = False
     count: bool = False
-    default: T | EmptyType | None = Empty
+    default: Default | T | EmptyType | None = Empty
     help: str | None = None
     parse: Callable[..., T] | Sequence[Callable[..., Any]] | None = None
     parse_inference: bool = True
@@ -420,7 +418,7 @@ class Arg(Generic[T]):
         default_short: bool = False,
         default_long: bool = False,
         state: State[Any] | None = None,
-    ) -> list[Arg[Any]]:
+    ) -> list[FinalArg[Any]]:
         args: list[Arg[Any]] = find_annotations(type_view, cls) or [Arg()]
 
         exclusive = field.name if len(args) > 1 else False
@@ -438,7 +436,7 @@ class Arg(Generic[T]):
         if field_metadata:
             args = field_metadata
 
-        result: list[Arg[Any]] = []
+        result: list[FinalArg[Any]] = []
         for i, arg in enumerate(args, start=1):
             # field_name and default are evaluated outside `normalize` because they can
             # potentially depend on the type's dataclass-like field information, whereas
@@ -480,7 +478,7 @@ class Arg(Generic[T]):
         state: State[Any] | None = None,
         destructure: Destructure | bool | None = None,
         show_default: bool | str | DefaultFormatter | None = None,
-    ) -> Arg[Any]:
+    ) -> FinalArg[Any]:
         if type_view is None:
             type_view = TypeView(Any)
 
@@ -517,28 +515,36 @@ class Arg(Generic[T]):
         )
 
         destructure = destructure or self.destructure
+        if not destructure:
+            destructure = None
         if destructure is True:
             destructure = Destructure()
 
-        result = dataclasses.replace(
-            self,
-            default=default,
-            field_name=field_name,
+        result: FinalArg[Any] = FinalArg(
+            # preserved from self
+            count=self.count,
+            hidden=self.hidden,
+            deprecated=self.deprecated,
+            propagate=self.propagate,
+            parse_inference=self.parse_inference,
+            # computed/narrowed
             value_name=value_name,
-            required=required,
             short=short,
             long=long,
-            choices=choices,
+            default=default,
+            help=help,
+            parse=parse,
+            group=group,
             action=action,
             num_args=num_args,
-            parse=parse,
-            help=help,
+            choices=choices,
             completion=completion,
-            group=group,
-            has_value=has_value,
-            type_view=type_view,
+            required=required,
+            field_name=field_name,
             show_default=default_formatter,
             destructure=destructure,
+            has_value=has_value,
+            type_view=type_view,
         )
         verify_type_compatibility(
             result, field_name, type_view, has_custom_parse=bool(self.parse)
@@ -550,19 +556,38 @@ class Arg(Generic[T]):
         """Mark a an argument as destructured. See also the shorter `Destructured` alias."""
         return cls(destructure=Destructure())
 
+
+@dataclasses.dataclass(frozen=True)
+class FinalArg(Arg[T]):
+    """Post-normalization form of :class:`Arg` with narrowed field types.
+
+    Produced exclusively by :meth:`Arg.normalize`. After normalization all
+    previously-optional/Empty fields are guaranteed to be concrete values.
+    """
+
+    value_name: str = ""
+    short: list[str] | Literal[False] = False
+    long: list[str] | Literal[False] = False
+    default: Default = dataclasses.field(default_factory=Default)
+    group: Group = dataclasses.field(default_factory=Group)
+    action: ArgActionType = ArgAction.set
+    num_args: NumArgs = dataclasses.field(default_factory=NumArgs)
+    required: bool = False
+    field_name: str = ""
+    has_value: bool = True
+    type_view: TypeView[Any] = dataclasses.field(default_factory=lambda: TypeView(Any))
+    parse: Callable[..., Any] = dataclasses.field(default=parse_value)
+    show_default: DefaultFormatter = dataclasses.field(default_factory=DefaultFormatter)
+    destructure: Destructure | None = None
+
     def names(self, *, n: int = 0) -> list[str]:
-        short_names = cast(List[str], self.short or [])
-        long_names = cast(List[str], self.long or [])
-        result = short_names + long_names
-        if n:
-            return result[:n]
-        return result
+        result = (self.short or []) + (self.long or [])
+        return result[:n] if n else result
 
     def names_str(self, delimiter: str = ", ", *, n: int = 0) -> str:
-        if self.long or self.short:
+        if self.short or self.long:
             return delimiter.join(self.names(n=n))
-
-        return cast(str, self.value_name)
+        return self.value_name
 
     @cached_property
     def is_option(self) -> bool:
@@ -570,7 +595,7 @@ class Arg(Generic[T]):
 
 
 def verify_type_compatibility(
-    arg: Arg[Any],
+    arg: FinalArg[Any],
     field_name: str,
     type_view: TypeView[Any],
     *,
@@ -591,7 +616,7 @@ def verify_type_compatibility(
     if has_custom_parse or ArgAction.is_custom(action):
         return
 
-    num_args = assert_type(arg.num_args, NumArgs)
+    num_args = arg.num_args
     if not num_args.required and num_args.default is None and not type_view.is_optional:
         raise ValueError(
             f"On field '{field_name}', `NumArgs(required=False, default=None)` requires the "
@@ -852,7 +877,9 @@ def infer_value_name(arg: Arg[Any], field_name: str, num_args: NumArgs) -> str:
     return field_name
 
 
-def explode_negated_bool_args(args: Sequence[Arg[Any]]) -> Iterable[Arg[Any]]:
+def explode_negated_bool_args(
+    args: Sequence[FinalArg[Any]],
+) -> Iterable[FinalArg[Any]]:
     """Expand `--foo/--no-foo` solo arguments into dual-arguments.
 
     Acts as a transform from `Arg(long='--foo/--no-foo')` to
@@ -861,7 +888,7 @@ def explode_negated_bool_args(args: Sequence[Arg[Any]]) -> Iterable[Arg[Any]]:
     for arg in args:
         yielded = False
         if isinstance(arg.action, ArgAction) and arg.action.is_bool_action and arg.long:
-            long = cast(List[str], arg.long)
+            long = arg.long
 
             negatives = [item for item in long if "--no-" in item]
             positives = [item for item in long if "--no-" not in item]
@@ -874,9 +901,9 @@ def explode_negated_bool_args(args: Sequence[Arg[Any]]) -> Iterable[Arg[Any]]:
                 default_is_false = arg.default.fallback_value is False and not_required
                 disabled: DefaultFormatter = DefaultFormatter.disabled()
                 group = dataclasses.replace(
-                    cast(Group, arg.group),
+                    arg.group,
                     exclusive=True,
-                    id=cast(str, arg.field_name),
+                    id=arg.field_name,
                 )
 
                 positive_arg = dataclasses.replace(

--- a/src/cappa/argparse.py
+++ b/src/cappa/argparse.py
@@ -2,15 +2,15 @@ from __future__ import annotations
 
 import argparse
 import sys
-from typing import TYPE_CHECKING, Any, Callable, Hashable, List, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Callable, Hashable, TypeVar, cast
 
-from cappa.arg import Arg, ArgAction, Group, NumArgs
-from cappa.command import Alias, Command, Subcommand
+from cappa.arg import Arg, ArgAction, FinalArg, NumArgs
+from cappa.command import Alias, Command, FinalCommand
 from cappa.help import ArgGroup
 from cappa.invoke.base import fulfill_deps
 from cappa.output import Exit, HelpExit, Output
 from cappa.parser import RawOption, Value
-from cappa.typing import assert_type
+from cappa.subcommand import FinalSubcommand
 
 if TYPE_CHECKING:
     from _typeshed import SupportsWrite
@@ -69,7 +69,7 @@ class _CountAction(argparse._CountAction):  # pyright: ignore
 
 class ArgumentParser(argparse.ArgumentParser):
     def __init__(
-        self, *args: Any, command: Command[Any], output: Output, **kwargs: Any
+        self, *args: Any, command: FinalCommand[Any], output: Output, **kwargs: Any
     ):
         super().__init__(*args, **kwargs)
         self.command = command
@@ -141,7 +141,7 @@ class Nestedspace(argparse.Namespace):
 
 
 def backend(
-    command: Command[T],
+    command: FinalCommand[T],
     argv: list[str],
     output: Output,
     prog: str,
@@ -173,7 +173,7 @@ def backend(
 
 
 def create_parser(
-    command: Command[Any], output: Output, prog: str
+    command: FinalCommand[Any], output: Output, prog: str
 ) -> argparse.ArgumentParser:
     kwargs: dict[str, Any] = {}
     if sys.version_info >= (3, 9):  # pragma: no cover
@@ -196,7 +196,7 @@ def create_parser(
 
 def add_arguments(
     parser: ArgumentParser,
-    command: Command[Any],
+    command: FinalCommand[Any],
     output: Output,
     dest_prefix: str = "",
 ):
@@ -209,13 +209,12 @@ def add_arguments(
         for field_group in group.field_groups:
             if field_group.args:
                 for arg in field_group.args:
-                    arg_group = cast(Group, arg.group)
                     target_group: Any = argparse_group
 
-                    if arg_group.exclusive:
-                        target_group = exclusive_groups.get(arg_group.id)
+                    if arg.group.exclusive:
+                        target_group = exclusive_groups.get(arg.group.id)
                         if target_group is None:
-                            target_group = exclusive_groups[arg_group.id] = (
+                            target_group = exclusive_groups[arg.group.id] = (
                                 argparse_group.add_mutually_exclusive_group()
                             )
 
@@ -234,7 +233,7 @@ def add_arguments(
 def add_argument(
     parser: ArgumentParser,  # pyright: ignore
     subparser: argparse.ArgumentParser | argparse._ArgumentGroup,  # pyright: ignore
-    arg: Arg[Any],
+    arg: FinalArg[Any],
     dest_prefix: str = "",
     **extra_kwargs: Any,
 ):
@@ -243,36 +242,33 @@ def add_argument(
 
     names: list[str] = []
     if arg.short:
-        short = cast(List[str], arg.short)
-        names.extend(short)
+        names.extend(arg.short)
 
     if arg.long:
-        long = cast(List[str], arg.long)
-        names.extend(long)
+        names.extend(arg.long)
 
     is_positional = not names
 
-    normalized_num_args = assert_type(arg.num_args, NumArgs)
-    num_args = backend_num_args(normalized_num_args, assert_type(arg.required, bool))
+    num_args = backend_num_args(arg.num_args, arg.required)
 
     kwargs: dict[str, Any] = {
-        "dest": dest_prefix + assert_type(arg.field_name, str),
+        "dest": dest_prefix + arg.field_name,
         "help": arg.help,
         "metavar": arg.value_name,
         "action": get_action(arg),
         "default": argparse.SUPPRESS,
     }
 
-    if not is_positional and arg.required and normalized_num_args.n >= 0:
+    if not is_positional and arg.required and arg.num_args.n >= 0:
         kwargs["required"] = arg.required
 
-    is_optional_value = not is_positional and not normalized_num_args.required
+    is_optional_value = not is_positional and not arg.num_args.required
 
     if num_args is not None and not ArgAction.is_non_value_consuming(arg.action):
         kwargs["nargs"] = num_args
     elif is_optional_value:
         kwargs["nargs"] = "?"
-        kwargs["const"] = normalized_num_args.default
+        kwargs["const"] = arg.num_args.default
     elif is_positional and not arg.required:
         kwargs["nargs"] = "?"
 
@@ -289,7 +285,7 @@ def add_argument(
 def add_subcommands(
     parser: argparse.ArgumentParser,
     group: str,
-    subcommands: Subcommand,
+    subcommands: FinalSubcommand,
     output: Output,
     dest_prefix: str = "",
 ):
@@ -297,7 +293,7 @@ def add_subcommands(
     visible_metavar = "{" + ",".join(subcommands.names()) + "}"
     subparsers = parser.add_subparsers(
         title=group,
-        required=assert_type(subcommands.required, bool),
+        required=subcommands.required,
         parser_class=ArgumentParser,
         metavar=visible_metavar,
     )

--- a/src/cappa/base.py
+++ b/src/cappa/base.py
@@ -17,7 +17,7 @@ from typing_extensions import dataclass_transform
 
 from cappa import argparse, parser
 from cappa.class_inspect import detect
-from cappa.command import Alias, Command
+from cappa.command import Alias, Command, FinalCommand
 from cappa.help import HelpFormattable, HelpFormatter
 from cappa.invoke.base import resolve_callable
 from cappa.invoke.types import DepTypes, InvokeCallableSpec
@@ -26,10 +26,12 @@ from cappa.state import S, State
 from cappa.types import Backend, CappaCapable, FuncOrClassDecorator, ParseResult, T, U
 
 if TYPE_CHECKING:
-    from cappa.arg import Arg
+    from cappa.arg import Arg, FinalArg
 
 
-def create_version_arg(version: str | Arg[Any] | None = None) -> Arg[Any] | None:
+def create_version_arg(
+    version: str | Arg[Any] | None = None,
+) -> FinalArg[Any] | None:
     from dataclasses import replace
 
     from cappa.arg import Arg, ArgAction, Empty, Group
@@ -60,7 +62,7 @@ def create_version_arg(version: str | Arg[Any] | None = None) -> Arg[Any] | None
     )
 
 
-def create_help_arg(help: bool | Arg[bool] | None = True) -> Arg[bool] | None:
+def create_help_arg(help: bool | Arg[bool] | None = True) -> FinalArg[bool] | None:
     from cappa.arg import Arg, ArgAction, Group
 
     if not help:
@@ -78,7 +80,9 @@ def create_help_arg(help: bool | Arg[bool] | None = True) -> Arg[bool] | None:
     return help.normalize(action=ArgAction.help, field_name="help", default=None)
 
 
-def create_completion_arg(completion: bool | Arg[bool] = True) -> Arg[bool] | None:
+def create_completion_arg(
+    completion: bool | Arg[bool] = True,
+) -> FinalArg[bool] | None:
     from cappa.arg import Arg, ArgAction, Group
 
     if not completion:
@@ -471,7 +475,7 @@ def parse_command(
     concrete_output = _coalesce_output(output, theme, color)
     concrete_state: State[S] = State.ensure(state)  # type: ignore
 
-    command: Command[T] = collect(
+    command: FinalCommand[T] = collect(
         obj,
         help=help,
         version=version,
@@ -480,8 +484,7 @@ def parse_command(
         help_formatter=help_formatter,
         state=concrete_state,
     )
-    return Command.parse_command(  # pyright: ignore
-        command,
+    return command.parse_command(
         argv=argv,
         input=input,
         backend=concrete_backend,
@@ -625,7 +628,7 @@ def collect(
     completion: bool | Arg[bool] = True,
     help_formatter: HelpFormattable | None = None,
     state: State[Any] | None = None,
-) -> Command[T]:
+) -> FinalCommand[T]:
     """Retrieve the `Command` object from a cappa-capable source class.
 
     Arguments:
@@ -647,8 +650,9 @@ def collect(
     """
     state = State.ensure(state)  # pyright: ignore
 
-    command: Command[T] = Command.get(obj, help_formatter=help_formatter)  # pyright: ignore
-    command = Command.collect(command, state=state)  # pyright: ignore
+    command: FinalCommand[T] = Command.get(  # pyright: ignore
+        obj, help_formatter=help_formatter
+    ).collect(state=state)
 
     concrete_backend = _coalesce_backend(backend)
     if concrete_backend is argparse.backend:  # pyright: ignore

--- a/src/cappa/command.py
+++ b/src/cappa/command.py
@@ -14,6 +14,7 @@ from typing import (
     Hashable,
     Iterable,
     Protocol,
+    Sequence,
     TextIO,
     TypedDict,
     TypeVar,
@@ -22,7 +23,7 @@ from typing import (
 
 from type_lens.type_view import TypeView
 
-from cappa.arg import Arg, Group
+from cappa.arg import Arg, FinalArg, Group
 from cappa.class_inspect import fields as get_fields
 from cappa.class_inspect import get_command, get_command_capable_object
 from cappa.default import Default
@@ -31,7 +32,7 @@ from cappa.help import HelpFormattable, HelpFormatter
 from cappa.invoke.types import Resolved
 from cappa.output import Exit, Output
 from cappa.state import S, State
-from cappa.subcommand import Subcommand
+from cappa.subcommand import FinalSubcommand, Subcommand
 from cappa.type_view import CallableView
 from cappa.types import ParseResult
 from cappa.typing import assert_type
@@ -113,10 +114,12 @@ class Command(Generic[T]):
     """
 
     cmd_cls: type[T]
-    arguments: list[Arg[Any] | Subcommand] = dataclasses.field(
+    arguments: Sequence[Arg[Any] | Subcommand] = dataclasses.field(
         default_factory=lambda: []
     )
-    propagated_arguments: list[Arg[Any]] = dataclasses.field(default_factory=lambda: [])
+    propagated_arguments: list[FinalArg[Any]] = dataclasses.field(
+        default_factory=lambda: []
+    )
 
     name: str | None = None
     aliases: list[str | Alias] = dataclasses.field(default_factory=lambda: [])
@@ -167,33 +170,31 @@ class Command(Generic[T]):
     def resolved_aliases(self) -> list[Alias]:
         return [Alias.coerce(a) for a in self.aliases]
 
-    @classmethod
     def collect(
-        cls,
-        command: Command[T],
-        propagated_arguments: list[Arg[Any]] | None = None,
+        self,
+        propagated_arguments: list[FinalArg[Any]] | None = None,
         state: State[Any] | None = None,
-    ) -> Command[T]:
+    ) -> FinalCommand[T]:
         kwargs: CommandArgs = CommandArgs()
 
-        help_text = ClassHelpText.collect(command.cmd_cls)
+        help_text = ClassHelpText.collect(self.cmd_cls)
 
-        if not command.help:
+        if not self.help:
             kwargs["help"] = help_text.summary
 
-        if not command.description:
+        if not self.description:
             kwargs["description"] = help_text.body
 
-        fields = get_fields(command.cmd_cls)
-        function_view = CallableView.from_callable(command.cmd_cls, include_extras=True)
+        fields = get_fields(self.cmd_cls)
+        function_view = CallableView.from_callable(self.cmd_cls, include_extras=True)
 
         propagated_arguments = propagated_arguments or []
 
-        arguments: list[Arg[Any]] = []
+        arguments: list[FinalArg[Any]] = []
         raw_subcommands: list[tuple[Subcommand, TypeView[Any] | None, str | None]] = []
-        if command.arguments:
+        if self.arguments:
             param_by_name = {p.name: p for p in function_view.parameters}
-            for arg in command.arguments:
+            for arg in self.arguments:
                 arg_help = help_text.args.get(assert_type(arg.field_name, str))
                 if isinstance(arg, Arg):
                     type_view = (
@@ -204,8 +205,8 @@ class Command(Generic[T]):
                     arguments.append(
                         arg.normalize(
                             type_view=type_view,
-                            default_short=command.default_short,
-                            default_long=command.default_long,
+                            default_short=self.default_short,
+                            default_long=self.default_long,
                             fallback_help=arg_help,
                             state=state,
                         )
@@ -230,12 +231,12 @@ class Command(Generic[T]):
                         )
                     )
                 else:
-                    arg_defs: list[Arg[Any]] = Arg.collect(
+                    arg_defs: list[FinalArg[Any]] = Arg.collect(
                         field,
                         param_view.type_view,
                         fallback_help=arg_help,
-                        default_short=command.default_short,
-                        default_long=command.default_long,
+                        default_short=self.default_short,
+                        default_long=self.default_long,
                         state=state,
                     )
                     arguments.extend(arg_defs)
@@ -248,7 +249,7 @@ class Command(Generic[T]):
             subcommand.normalize(
                 type_view,
                 field_name,
-                help_formatter=command.help_formatter,
+                help_formatter=self.help_formatter,
                 propagated_arguments=propagating_arguments,
                 state=state,
             )
@@ -256,140 +257,87 @@ class Command(Generic[T]):
         ]
 
         check_group_identity(arguments)
-        kwargs["arguments"] = [*arguments, *subcommands]
+        final_arguments: list[FinalArg[Any] | FinalSubcommand] = [
+            *arguments,
+            *subcommands,
+        ]
 
-        return dataclasses.replace(
-            command,
-            **kwargs,
+        return FinalCommand(
+            cmd_cls=self.cmd_cls,
+            arguments=final_arguments,
             propagated_arguments=propagated_arguments,
+            name=self.name,
+            aliases=self.aliases,
+            help=kwargs.get("help", self.help),
+            description=kwargs.get("description", self.description),
+            invoke=self.invoke,
+            hidden=self.hidden,
+            default_short=self.default_short,
+            default_long=self.default_long,
+            deprecated=self.deprecated,
+            help_formatter=self.help_formatter,
+            _collected=self._collected,
         )
 
-    @classmethod
-    def parse_command(
-        cls,
-        command: Command[T],
-        *,
-        output: Output,
-        backend: Backend,
-        argv: list[str] | None = None,
-        input: TextIO | None = None,
-        state: State[S] | None = None,
-    ) -> ParseResult[T, S]:
-        if argv is None:  # pragma: no cover
-            argv = sys.argv[1:]
 
-        prog = command.real_name()
-        result_state: State[S] = State.ensure(state)  # type: ignore
+@dataclasses.dataclass
+class FinalCommand(Command[T]):
+    """Post-normalization form of :class:`Command` with narrowed field types.
 
-        with graceful_exit(command, prog, output):
-            parser, parsed_command, parsed_args = backend(
-                command, argv, output=output, prog=prog
-            )
-            prog = parser.prog
-            result, implicit_deps = command.map_result(
-                command, prog, parsed_args, state=state, input=input, output=output
-            )
+    Produced exclusively by :meth:`Command.collect`.
+    """
 
-        return ParseResult(
-            root_command=command,
-            parsed_command=parsed_command,
-            instance=result,
-            implicit_deps=implicit_deps,
-            output=output,
-            state=result_state,
-        )
-
-    def map_result(
-        self,
-        command: Command[T],
-        prog: str,
-        parsed_args: dict[str, Any],
-        output: Output,
-        state: State[Any] | None = None,
-        input: TextIO | None = None,
-    ) -> tuple[Resolved[T], dict[Hashable, Any]]:
-        state = State.ensure(state)  # pyright: ignore
-
-        kwargs: dict[str, Any] = {}
-        for arg in self.value_arguments:
-            field_name = cast(str, arg.field_name)
-
-            if arg.field_name in parsed_args:
-                is_parsed, value = (False, parsed_args[field_name])
-            else:
-                assert isinstance(arg.default, Default), arg
-                is_parsed, value = arg.default(state=state, input=input)
-
-            handler = parse_handler(arg, prog, value)
-
-            kwargs[field_name] = Resolved(handler, args=(value, is_parsed))
-
-        # Collect all subcommand instances during construction
-        subcommand_deps: dict[Hashable, Any] = {}
-        subcommand = self.subcommand
-        if subcommand:
-            field_name = cast(str, subcommand.field_name)
-            if field_name in parsed_args:
-                value = parsed_args[field_name]
-                value, subcommand_deps = subcommand.map_result(
-                    prog, value, output=output, state=state
-                )
-                kwargs[field_name] = value
-
-        def map_result(**kwargs: dict[str, Any]) -> T:
-            with graceful_exit(command, prog, output):
-                return command.cmd_cls(**kwargs)
-
-        resolved = Resolved(map_result, kwargs=kwargs)
-
-        # Add this command instance to deps
-        key = cast(Hashable, command.cmd_cls)
-        deps: dict[Hashable, Any] = {key: resolved, **subcommand_deps}
-
-        return resolved, deps
+    arguments: Sequence[FinalArg[Any] | FinalSubcommand] = dataclasses.field(  # pyright: ignore
+        default_factory=list
+    )
+    propagated_arguments: list[FinalArg[Any]] = dataclasses.field(  # pyright: ignore
+        default_factory=list
+    )
 
     @property
-    def subcommand(self) -> Subcommand | None:
+    def subcommand(self) -> FinalSubcommand | None:
         return next(
-            (arg for arg in self.arguments if isinstance(arg, Subcommand)), None
+            (arg for arg in self.arguments if isinstance(arg, FinalSubcommand)),
+            None,
         )
 
     @property
-    def value_arguments(self) -> Iterable[Arg[Any]]:
+    def value_arguments(self) -> Iterable[FinalArg[Any]]:
         for arg in self.arguments:
-            if isinstance(arg, Arg) and arg.has_value:
+            if isinstance(arg, FinalArg) and arg.has_value:
                 yield arg
 
     @property
-    def all_arguments(self) -> Iterable[Arg[Any] | Subcommand]:
+    def all_arguments(self) -> Iterable[FinalArg[Any] | FinalSubcommand]:
         for arg in self.arguments:
             yield arg
-
         for arg in self.propagated_arguments:
             yield arg
 
     @property
-    def options(self) -> Iterable[Arg[Any]]:
+    def options(self) -> Iterable[FinalArg[Any]]:
         for arg in self.arguments:
-            if isinstance(arg, Arg) and arg.is_option:
+            if isinstance(arg, FinalArg) and arg.is_option:
                 yield arg
 
     @property
-    def positional_arguments(self) -> Iterable[Arg[Any] | Subcommand]:
+    def positional_arguments(
+        self,
+    ) -> Iterable[FinalArg[Any] | FinalSubcommand]:
         for arg in self.arguments:
             if (
-                isinstance(arg, Arg)
+                isinstance(arg, FinalArg)
                 and not arg.short
                 and not arg.long
                 and not arg.destructure
-            ) or isinstance(arg, Subcommand):
+            ) or isinstance(arg, FinalSubcommand):
                 yield arg
 
     def add_meta_actions(
         self,
-        help: Arg[bool] | None = None,
-        version: Arg[str] | None = None,
-        completion: Arg[bool] | None = None,
+        help: FinalArg[bool] | None = None,
+        version: FinalArg[str] | None = None,
+        completion: FinalArg[bool] | None = None,
     ):
         if self._collected:
             return self
@@ -402,7 +350,7 @@ class Command(Generic[T]):
                     for name, option in arg.options.items()
                 },
             )
-            if help and isinstance(arg, Subcommand)
+            if help and isinstance(arg, FinalSubcommand)
             else arg
             for arg in self.arguments
         ]
@@ -415,6 +363,83 @@ class Command(Generic[T]):
             arguments.append(completion)
         return dataclasses.replace(self, arguments=arguments, _collected=True)
 
+    def map_result(
+        self,
+        command: FinalCommand[T],
+        prog: str,
+        parsed_args: dict[str, Any],
+        output: Output,
+        state: State[Any] | None = None,
+        input: TextIO | None = None,
+    ) -> tuple[Resolved[T], dict[Hashable, Any]]:
+        state = State.ensure(state)  # pyright: ignore
+
+        kwargs: dict[str, Any] = {}
+        for arg in self.value_arguments:
+            field_name = arg.field_name
+
+            if field_name in parsed_args:
+                is_parsed, value = (False, parsed_args[field_name])
+            else:
+                assert isinstance(arg.default, Default), arg
+                is_parsed, value = arg.default(state=state, input=input)
+
+            handler = parse_handler(arg, prog, value)
+            kwargs[field_name] = Resolved(handler, args=(value, is_parsed))
+
+        subcommand_deps: dict[Hashable, Any] = {}
+        subcommand = self.subcommand
+        if subcommand:
+            field_name = subcommand.field_name
+            if field_name in parsed_args:
+                value = parsed_args[field_name]
+                value, subcommand_deps = subcommand.map_result(
+                    prog, value, output=output, state=state
+                )
+                kwargs[field_name] = value
+
+        def map_result(**kwargs: dict[str, Any]) -> T:
+            with graceful_exit(command, prog, output):
+                return command.cmd_cls(**kwargs)
+
+        resolved = Resolved(map_result, kwargs=kwargs)
+        key = cast(Hashable, command.cmd_cls)
+        deps: dict[Hashable, Any] = {key: resolved, **subcommand_deps}
+        return resolved, deps
+
+    def parse_command(
+        self,
+        *,
+        output: Output,
+        backend: Backend,
+        argv: list[str] | None = None,
+        input: TextIO | None = None,
+        state: State[S] | None = None,
+    ) -> ParseResult[T, S]:
+        if argv is None:  # pragma: no cover
+            argv = sys.argv[1:]
+
+        prog = self.real_name()
+        result_state: State[S] = State.ensure(state)  # type: ignore
+
+        with graceful_exit(self, prog, output):
+            parser, parsed_command, parsed_args = backend(
+                self, argv, output=output, prog=prog
+            )
+            prog = parser.prog
+            result, implicit_deps = self.map_result(
+                self, prog, parsed_args, state=state, input=input, output=output
+            )
+
+        return ParseResult(
+            root_command=self,
+            parsed_command=parsed_command,
+            instance=result,
+            implicit_deps=implicit_deps,
+            output=output,
+            state=result_state,
+        )
+
 
 H = TypeVar("H", covariant=True)
 
@@ -423,30 +448,24 @@ class HasCommand(Generic[H], Protocol):
     __cappa__: ClassVar[Command[Any]]
 
 
-def check_group_identity(args: list[Arg[Any]]):
+def check_group_identity(args: list[FinalArg[Any]]):
     group_identity: dict[str, Group] = {}
 
     for arg in args:
-        assert isinstance(arg.group, Group)
-
         identity = group_identity.get(arg.group.id)
         if identity and identity != arg.group:
             raise ValueError(
                 f"Group details do not match among arguments: {arg.group.diff(identity)}."
             )
 
-        assert isinstance(arg.group, Group)
         group_identity[arg.group.id] = arg.group
 
 
 @contextlib.contextmanager
 def parse_value(
-    arg: Arg[T], prog: str, value: Any, is_parsed: bool
+    arg: FinalArg[T], prog: str, value: Any, is_parsed: bool
 ) -> Generator[T, None, None]:
     if not is_parsed:
-        assert arg.parse
-        assert callable(arg.parse)
-
         try:
             value = arg.parse(value)
         except Exception as e:
@@ -460,11 +479,13 @@ def parse_value(
     yield value
 
 
-def parse_handler(arg: Arg[T], prog: str, value: Any) -> Callable[[Any, bool], Any]:
+def parse_handler(
+    arg: FinalArg[T], prog: str, value: Any
+) -> Callable[[Any, bool], Any]:
     is_async_value = inspect.iscoroutine(value)
-    is_async_parse = arg.parse and (
-        inspect.iscoroutinefunction(arg.parse) or inspect.isasyncgenfunction(arg.parse)
-    )
+    is_async_parse = inspect.iscoroutinefunction(
+        arg.parse
+    ) or inspect.isasyncgenfunction(arg.parse)
 
     if is_async_value or is_async_parse:
 
@@ -498,7 +519,7 @@ def parse_handler(arg: Arg[T], prog: str, value: Any) -> Callable[[Any, bool], A
 
 @contextlib.contextmanager
 def graceful_exit(
-    command: Command[T], prog: str, output: Output
+    command: FinalCommand[T], prog: str, output: Output
 ) -> Generator[None, None, None]:
     try:
         yield

--- a/src/cappa/completion/base.py
+++ b/src/cappa/completion/base.py
@@ -5,14 +5,18 @@ from pathlib import Path
 from typing import Any, Iterable, cast
 
 from cappa.arg import Arg
-from cappa.command import Command
+from cappa.command import FinalCommand
 from cappa.completion.shells import available_shells
 from cappa.output import Exit, Output
 from cappa.parser import Completion, FileCompletion, backend
 
 
 def execute(
-    command: Command[Any], prog: str, action: str, arg: Arg[Any], output: Output
+    command: FinalCommand[Any],
+    prog: str,
+    action: str,
+    arg: Arg[Any],
+    output: Output,
 ):
     shell_name = Path(os.environ.get("SHELL", "bash")).name
     shell = available_shells.get(shell_name)

--- a/src/cappa/destructure.py
+++ b/src/cappa/destructure.py
@@ -1,16 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Any, Hashable, TypeVar
+from typing import Any, Hashable, TypeVar
 
 from type_lens import TypeView
 from typing_extensions import Annotated
 
+from cappa.arg import Arg, ArgActionType, FinalArg
 from cappa.output import Output
-from cappa.typing import assert_type
-
-if TYPE_CHECKING:
-    from cappa.arg import Arg, ArgActionType
 
 
 @dataclass(frozen=True)
@@ -22,14 +19,14 @@ T = TypeVar("T")
 Destructured = Annotated[T, Destructure()]
 
 
-def destructure(arg: Arg[Any], type_view: TypeView[Any]) -> list[Arg[Any]]:
+def destructure(arg: FinalArg[Any], type_view: TypeView[Any]) -> list[FinalArg[Any]]:
     annotation = type_view.strip_optional().annotation
     if not isinstance(annotation, type):
         raise ValueError(
             "Destructured arguments currently only support singular concrete types."
         )
 
-    command: Command[Any] = Command.collect(Command.get(annotation))  # pyright: ignore
+    command: FinalCommand[Any] = Command.get(annotation).collect()  # pyright: ignore
     virtual_args = command.arguments
 
     def _parse_destructured(value: dict[str, Any]):
@@ -44,7 +41,6 @@ def destructure(arg: Arg[Any], type_view: TypeView[Any]) -> list[Arg[Any]]:
                 "Subcommands are unsupported in the context of a destructured argument"
             )
 
-        assert virtual_arg.action
         virtual_arg = replace(
             virtual_arg,
             action=restructure(arg, virtual_arg.action),
@@ -56,36 +52,38 @@ def destructure(arg: Arg[Any], type_view: TypeView[Any]) -> list[Arg[Any]]:
     return result
 
 
-def restructure(root_arg: Arg[Any], action: ArgActionType):
+def restructure(root_arg: FinalArg[Any], action: ArgActionType):
     action_handler = determine_action_handler(action)
 
     def restructure_action(
-        parse_state: ParseState, context: ParseContext, arg: Arg[Any], value: Value[Any]
+        parse_state: ParseState,
+        context: ParseContext,
+        arg: FinalArg[Any],
+        value: Value[Any],
     ):
-        root_field_name = assert_type(root_arg.field_name, str)
+        root_field_name = root_arg.field_name
         result = context.result.setdefault(root_field_name, {})
         nested_context = replace(context, result=result)
 
         fulfilled_deps: dict[Hashable, Any] = {
             Command: parse_state.current_command,
+            FinalCommand: parse_state.current_command,
             Output: parse_state.output,
             ParseContext: nested_context,
             Arg: arg,
+            FinalArg: arg,
             Value: value,
         }
         deps = fulfill_deps(action_handler, fulfilled_deps)
         action_result = action_handler(**deps.kwargs)
 
-        assert arg.parse
-        assert callable(arg.parse)
         result[arg.field_name] = arg.parse(action_result)
         return result
 
     return restructure_action
 
 
-from cappa.arg import Arg  # noqa: E402
-from cappa.command import Command  # noqa: E402
+from cappa.command import Command, FinalCommand  # noqa: E402
 from cappa.invoke.base import fulfill_deps  # noqa: E402
 from cappa.parser import (  # noqa: E402
     ParseContext,

--- a/src/cappa/ext/docutils.py
+++ b/src/cappa/ext/docutils.py
@@ -4,12 +4,12 @@ import importlib
 import importlib.util
 import io
 import logging
-from typing import TYPE_CHECKING, Any, ClassVar, Sequence, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Sequence
 
 from rich.console import Console
 
 import cappa
-from cappa.command import Command
+from cappa.command import FinalCommand
 from cappa.default import Default
 from cappa.help import ArgGroup, HelpFormatter
 from cappa.output import Displayable, theme
@@ -58,7 +58,7 @@ class CappaDirective(Directive):
         module = importlib.import_module(module_path)
         item = getattr(module, item_name)
 
-        command: Command[Any] = cappa.collect(item)
+        command: FinalCommand[Any] = cappa.collect(item)
         if style == "terminal":
             return render_to_terminal(command, terminal_width)
 
@@ -68,7 +68,7 @@ class CappaDirective(Directive):
         raise ValueError(f"Unrecognized style {style}")
 
 
-def render_to_terminal(command: cappa.Command[Any], terminal_width: int):
+def render_to_terminal(command: cappa.FinalCommand[Any], terminal_width: int):
     raw_help: list[Displayable] = HelpFormatter.default.long(
         command, command.real_name()
     )
@@ -94,7 +94,7 @@ def render_to_terminal(command: cappa.Command[Any], terminal_width: int):
     return [nodes.raw(text=html, format="html")]
 
 
-def render_to_docutils(command: cappa.Command[Any], document: nodes.document):
+def render_to_docutils(command: cappa.FinalCommand[Any], document: nodes.document):
     section = nodes.section()
     document.note_implicit_target(section)
 
@@ -113,8 +113,8 @@ def render_to_docutils(command: cappa.Command[Any], document: nodes.document):
 
     for group in ArgGroup.collect(command):
         # Collect all Args and Subcommands from field_groups
-        command_options: list[cappa.Arg[Any]] = []
-        command_subcommands: list[cappa.Subcommand] = []
+        command_options: list[cappa.FinalArg[Any]] = []
+        command_subcommands: list[cappa.FinalSubcommand] = []
         for field_group in group.field_groups:
             if field_group.args:
                 command_options.extend(field_group.args)
@@ -137,8 +137,8 @@ def render_to_docutils(command: cappa.Command[Any], document: nodes.document):
                     for name in names:
                         option_content += nodes.literal(text=name)
                 else:
-                    name = cast(str, arg.field_name)
-                    value_name = cast(str, arg.value_name)
+                    name = arg.field_name
+                    value_name = arg.value_name
 
                     name += f" {value_name.upper()}"
                     option_content += nodes.literal(text=name)

--- a/src/cappa/help.py
+++ b/src/cappa/help.py
@@ -13,15 +13,12 @@ from rich.table import Table
 from rich.text import Text
 from typing_extensions import Self, TypeAlias
 
-from cappa.arg import Arg, ArgAction, Group, NumArgs
-from cappa.default import Default, DefaultFormatter
+from cappa.arg import Arg, ArgAction, FinalArg
 from cappa.output import Displayable
-from cappa.subcommand import Subcommand
-from cappa.type_view import Empty
-from cappa.typing import assert_type
+from cappa.subcommand import FinalSubcommand
 
 if typing.TYPE_CHECKING:
-    from cappa.command import Command
+    from cappa.command import FinalCommand
 
 Dimension: TypeAlias = typing.Tuple[int, int, int, int]
 
@@ -35,8 +32,8 @@ class FieldGroup:
 
     field_name: str | None
     required: bool
-    args: list[Arg[Any]] | None = None
-    subcommand: Subcommand | None = None
+    args: list[FinalArg[Any]] | None = None
+    subcommand: FinalSubcommand | None = None
 
 
 @dataclass(frozen=True)
@@ -47,16 +44,18 @@ class ArgGroup:
     field_groups: list[FieldGroup]
 
     @staticmethod
-    def _by_group_key(arg: Arg[Any] | Subcommand) -> tuple[int, int, str, bool]:
-        return assert_type(arg.group, Group).key
+    def _by_group_key(
+        arg: FinalArg[Any] | FinalSubcommand,
+    ) -> tuple[int, int, str, bool]:
+        return arg.group.key
 
     @staticmethod
-    def _by_group(arg: Arg[Any] | Subcommand) -> str:
-        return assert_type(arg.group, Group).name
+    def _by_group(arg: FinalArg[Any] | FinalSubcommand) -> str:
+        return arg.group.name
 
     @classmethod
     def collect(
-        cls, command: Command[Any], include_hidden: bool = False
+        cls, command: FinalCommand[Any], include_hidden: bool = False
     ) -> list[ArgGroup]:
         """Collect and group arguments from a command by their Group."""
         sorted_args = sorted(command.all_arguments, key=cls._by_group_key)
@@ -65,9 +64,9 @@ class ArgGroup:
         for name, args in groupby(sorted_args, key=cls._by_group):
             items = [a for a in args if include_hidden or not a.hidden]
 
-            field_grouped: dict[str | None, list[Arg[Any] | Subcommand]] = {}
+            field_grouped: dict[str | None, list[FinalArg[Any] | FinalSubcommand]] = {}
             for item in items:
-                field_name = item.field_name if item.field_name is not Empty else None
+                field_name = item.field_name or None
                 if field_name not in field_grouped:
                     field_grouped[field_name] = []
                 field_grouped[field_name].append(item)
@@ -76,14 +75,14 @@ class ArgGroup:
             for field_name, items in field_grouped.items():
                 # Validate that items are all Args or all Subcommands
                 first_item = items[0]
-                if isinstance(first_item, Arg):
+                if isinstance(first_item, FinalArg):
                     # Validate all are Args
-                    if not all(isinstance(item, Arg) for item in items):
+                    if not all(isinstance(item, FinalArg) for item in items):
                         raise ValueError(  # pragma: no cover
                             f"FieldGroup with field_name={field_name!r} contains mixed types: "
                             f"Args and Subcommands cannot share the same field_name"
                         )
-                    group_args = cast(List[Arg[Any]], items)
+                    group_args = cast(List[FinalArg[Any]], items)
 
                     # All items must have the same requiredness
                     required_values = {arg.required for arg in group_args}
@@ -91,16 +90,17 @@ class ArgGroup:
                         f"All items with field_name={field_name!r} must have the same "
                         f"required value, got: {required_values}"
                     )
-                    required = cast(bool, required_values.pop())
+                    required = required_values.pop()
                     field_groups.append(
                         FieldGroup(field_name, required, args=group_args)
                     )
                 else:
                     assert len(items) == 1
+                    assert isinstance(first_item, FinalSubcommand)
                     field_groups.append(
                         FieldGroup(
                             field_name,
-                            cast(bool, first_item.required),
+                            first_item.required,
                             subcommand=first_item,
                         )
                     )
@@ -124,11 +124,11 @@ class HelpFormattable(typing.Protocol):
     default_format: str
 
     def long(
-        self, command: Command[Any], prog: str
+        self, command: FinalCommand[Any], prog: str
     ) -> list[Displayable]: ...  # pragma: no cover
 
     def short(
-        self, command: Command[Any], prog: str
+        self, command: FinalCommand[Any], prog: str
     ) -> Displayable: ...  # pragma: no cover
 
 
@@ -144,7 +144,7 @@ class HelpFormatter(HelpFormattable):
 
     default: typing.ClassVar[HelpFormatter]
 
-    def long(self, command: Command[Any], prog: str) -> list[Displayable]:
+    def long(self, command: FinalCommand[Any], prog: str) -> list[Displayable]:
         arg_groups = ArgGroup.collect(command)
 
         lines: list[Displayable] = []
@@ -161,7 +161,7 @@ class HelpFormatter(HelpFormattable):
         lines.extend(add_long_args(console, self, arg_groups))
         return lines
 
-    def short(self, command: Command[Any], prog: str) -> Displayable:
+    def short(self, command: FinalCommand[Any], prog: str) -> Displayable:
         arg_groups = ArgGroup.collect(command)
         return add_short_args(prog, arg_groups)
 
@@ -219,15 +219,12 @@ def add_long_args(
 
 
 def format_args(
-    console: Console, help_formatter: HelpFormattable, *args: Arg[Any]
+    console: Console, help_formatter: HelpFormattable, *args: FinalArg[Any]
 ) -> Displayable:
     """Format multiple args with the same field_name by concatenating their help texts."""
     segments: list[TextComponent] = []
 
     for arg in args:
-        assert isinstance(arg.default, Default)
-        assert isinstance(arg.show_default, DefaultFormatter)
-
         unknown_arg_format = help_formatter.arg_format
         if isinstance(unknown_arg_format, Iterable) and not isinstance(
             unknown_arg_format, str
@@ -328,8 +325,8 @@ def _replace_rich_text_component(c: TextComponent, text: str) -> TextComponent:
 
 def format_subcommand(
     help_formatter: HelpFormatter,
-    command: Command[Any],
-    subcommand: Subcommand | None = None,
+    command: FinalCommand[Any],
+    subcommand: FinalSubcommand | None = None,
 ):
     canonical = command.real_name()
     parts = [f"[cappa.subcommand]{canonical}[/cappa.subcommand]"]
@@ -363,7 +360,7 @@ def format_arg_name(item: FieldGroup, delimiter: str, *, n: int = 0) -> str:
     if item.args:
         parts: list[str] = []
         for arg in item.args:
-            num_args = cast(NumArgs, arg.num_args)
+            num_args = arg.num_args
             has_value = (
                 not ArgAction.is_non_value_consuming(arg.action) and num_args.n != 0
             )
@@ -378,7 +375,7 @@ def format_arg_name(item: FieldGroup, delimiter: str, *, n: int = 0) -> str:
             text = f"[cappa.arg]{arg_names}[/cappa.arg]"
 
             if arg.is_option and has_value:
-                name = cast(str, arg.value_name).upper()
+                name = arg.value_name.upper()
                 if num_args.n == -1:
                     name = f"{name} ..."
 

--- a/src/cappa/output.py
+++ b/src/cappa/output.py
@@ -11,7 +11,7 @@ from rich.theme import Theme
 from typing_extensions import TypeAlias
 
 if TYPE_CHECKING:
-    from cappa.command import Command
+    from cappa.command import FinalCommand
 
 __all__ = [
     "Displayable",
@@ -34,7 +34,7 @@ class Exit(SystemExit):
         self,
         message: list[Displayable] | Displayable | None = None,
         *,
-        command: Command[Any] | None = None,
+        command: FinalCommand[Any] | None = None,
         code: str | int | None = 0,
         prog: str | None = None,
     ):

--- a/src/cappa/parser.py
+++ b/src/cappa/parser.py
@@ -10,18 +10,17 @@ from typing import (
     Generic,
     Hashable,
     Iterable,
-    List,
-    Optional,
     cast,
 )
 
-from cappa.arg import Arg, ArgAction, ArgActionType, Group, NumArgs
-from cappa.command import Alias, Command, Subcommand
+from cappa.arg import Arg, ArgAction, ArgActionType, FinalArg
+from cappa.command import Alias, Command, FinalCommand
 from cappa.completion.types import Completion, FileCompletion
 from cappa.help import format_args, format_subcommand_names
 from cappa.invoke.base import fulfill_deps
 from cappa.output import Exit, HelpExit, Output
-from cappa.typing import T, assert_type
+from cappa.subcommand import FinalSubcommand
+from cappa.typing import T
 
 negative_number = re.compile(r"^-\d+$|^-\d*\.\d+$")
 
@@ -32,8 +31,8 @@ class BadArgumentError(RuntimeError):
         message: str,
         *,
         value: Any,
-        command: Command[Any],
-        arg: Arg[Any] | Subcommand | None = None,
+        command: FinalCommand[Any],
+        arg: Arg[Any] | FinalSubcommand | None = None,
     ) -> None:
         super().__init__(message)
         self.value = value
@@ -43,11 +42,11 @@ class BadArgumentError(RuntimeError):
 
 @dataclasses.dataclass
 class HelpAction(RuntimeError):
-    command: Command[Any]
+    command: FinalCommand[Any]
     command_name: str
 
     @classmethod
-    def from_parse_state(cls, parse_state: ParseState, command: Command[Any]):
+    def from_parse_state(cls, parse_state: ParseState, command: FinalCommand[Any]):
         raise cls(command, parse_state.prog)
 
 
@@ -77,12 +76,12 @@ class CompletionAction(RuntimeError):
 
 
 def backend(
-    command: Command[T],
+    command: FinalCommand[T],
     argv: list[str],
     output: Output,
     prog: str,
     provide_completions: bool = False,
-) -> tuple[Any, Command[T], dict[str, Any]]:
+) -> tuple[Any, FinalCommand[T], dict[str, Any]]:
     context = ParseContext.from_command(command)
     parse_state = ParseState.from_command(
         argv, command, output=output, provide_completions=provide_completions
@@ -125,7 +124,7 @@ class ParseState:
     """The overall state of the argument parse."""
 
     args: ArgCollection
-    command_stack: list[Command[Any]]
+    command_stack: list[FinalCommand[Any]]
     output: Output
     provide_completions: bool = False
 
@@ -133,7 +132,7 @@ class ParseState:
     def from_command(
         cls,
         argv: list[str],
-        command: Command[Any],
+        command: FinalCommand[Any],
         output: Output,
         provide_completions: bool = False,
     ):
@@ -153,7 +152,7 @@ class ParseState:
     def prog(self):
         return " ".join(c.real_name() for c in self.command_stack)
 
-    def push_command(self, command: Command[Any]):
+    def push_command(self, command: FinalCommand[Any]):
         self.command_stack.append(command)
 
 
@@ -161,34 +160,36 @@ class ParseState:
 class ParseContext:
     """The parsing context specific to a command."""
 
-    command: Command[Any]
-    arguments: deque[Arg[Any] | Subcommand]
+    command: FinalCommand[Any]
+    arguments: deque[FinalArg[Any] | FinalSubcommand]
     missing_options: set[str]
-    arguments_by_field_name: dict[str, list[Arg[Any]]]
-    arguments_by_value_name: dict[str, Arg[Any]]
+    arguments_by_field_name: dict[str, list[FinalArg[Any]]]
+    arguments_by_value_name: dict[str, FinalArg[Any]]
     propagated_options: set[str]
     parent_context: ParseContext | None = None
-    exclusive_args: dict[str, Arg[Any]] = dataclasses.field(default_factory=lambda: {})
+    exclusive_args: dict[str, FinalArg[Any]] = dataclasses.field(
+        default_factory=lambda: {}
+    )
 
     result: dict[str, Any] = dataclasses.field(default_factory=lambda: {})
 
     @classmethod
     def from_command(
         cls,
-        command: Command[Any],
+        command: FinalCommand[Any],
         parent_context: ParseContext | None = None,
     ) -> ParseContext:
-        arguments_by_field_name: dict[str, list[Arg[Any]]] = {}
-        arguments_by_value_name: dict[str, Arg[Any]] = {}
+        arguments_by_field_name: dict[str, list[FinalArg[Any]]] = {}
+        arguments_by_value_name: dict[str, FinalArg[Any]] = {}
         propagated_options: set[str] = set()
         unique_field_names: set[str] = set()
 
-        def add_option_names(arg: Arg[Any]):
+        def add_option_names(arg: FinalArg[Any]):
             for opts in (arg.short, arg.long):
                 if not opts:
                     continue
 
-                for key in cast(List[str], opts):
+                for key in opts:
                     if key in arguments_by_value_name:
                         raise ValueError(f"Conflicting option string: {key}")
 
@@ -196,7 +197,7 @@ class ParseContext:
 
         native_command_field_names: set[str] = set()
         for arg in command.options:
-            field_name = cast(str, arg.field_name)
+            field_name = arg.field_name
 
             if arg.action not in ArgAction.meta_actions():
                 unique_field_names.add(field_name)
@@ -206,7 +207,7 @@ class ParseContext:
             add_option_names(arg)
 
         for arg in command.propagated_arguments:
-            field_name = cast(str, arg.field_name)
+            field_name = arg.field_name
 
             if field_name in native_command_field_names:
                 continue
@@ -232,11 +233,7 @@ class ParseContext:
         parent_context = (
             self.parent_context.propagated_context if self.parent_context else {}
         )
-        self_options = {
-            assert_type(o.field_name, str): o
-            for o in self.command.options
-            if o.propagate
-        }
+        self_options = {o.field_name: o for o in self.command.options if o.propagate}
         self_context: dict[str, ParseContext] = dict.fromkeys(self_options, self)
         return {**parent_context, **self_context}
 
@@ -262,7 +259,7 @@ class ParseContext:
         if has_value:
             self.result[field_name] = value
 
-    def push(self, command: Command[Any], name: str) -> ParseContext:
+    def push(self, command: FinalCommand[Any], name: str) -> ParseContext:
         nested_context = ParseContext.from_command(command, parent_context=self)
         nested_context.result["__name__"] = name
         return nested_context
@@ -347,7 +344,7 @@ class ArgCollection:
 
                 # An option which requires consuming further arguments should consume
                 # the rest of the concatenated character sequence as its value.
-                if assert_type(option.num_args, NumArgs).n:
+                if option.num_args.n:
                     partial_arg = remaining_arg
                     break
 
@@ -440,7 +437,7 @@ def parse_option(
     parse_state: ParseState, context: ParseContext, raw: RawOption
 ) -> None:
     if raw.name not in context.arguments_by_value_name:
-        possible_options: dict[str, Arg[Any]] = {
+        possible_options: dict[str, FinalArg[Any]] = {
             name: arg
             for name, arg in context.arguments_by_value_name.items()
             if name.startswith(raw.name)
@@ -482,7 +479,7 @@ def parse_args(parse_state: ParseState, context: ParseContext) -> None:
 
         arg = context.next_argument()
 
-        if isinstance(arg, Subcommand):
+        if isinstance(arg, FinalSubcommand):
             consume_subcommand(parse_state, context, arg)
         else:
             consume_arg(parse_state, context, arg)
@@ -507,7 +504,7 @@ def parse_args(parse_state: ParseState, context: ParseContext) -> None:
 
 
 def consume_subcommand(
-    parse_state: ParseState, context: ParseContext, arg: Subcommand
+    parse_state: ParseState, context: ParseContext, arg: FinalSubcommand
 ) -> Any:
     value = parse_state.args.next(context)
     if value is None:
@@ -550,8 +547,7 @@ def consume_subcommand(
 
     parse(parse_state, nested_context)
 
-    name = cast(str, arg.field_name)
-    context.result[name] = nested_context.result
+    context.result[arg.field_name] = nested_context.result
 
 
 def iter_arg_values(
@@ -585,7 +581,7 @@ def iter_arg_values(
 
 
 def arg_bypasses_action(
-    arg: Arg[Any],
+    arg: FinalArg[Any],
     values: list[str],
     expected_count: int,
     option: RawOption | None,
@@ -657,14 +653,14 @@ def arg_bypasses_action(
 
 
 def check_exclusive_group(
-    arg: Arg[Any],
+    arg: FinalArg[Any],
     context: ParseContext,
     result: Any,
     parse_state: ParseState,
 ) -> None:
     """Check if arg violates exclusive group constraints."""
-    group = cast(Optional[Group], arg.group)
-    if not group or not group.exclusive:
+    group = arg.group
+    if not group.exclusive:
         return
 
     exclusive_arg = context.exclusive_args.get(group.id)
@@ -684,13 +680,13 @@ def check_exclusive_group(
 def consume_arg(
     parse_state: ParseState,
     context: ParseContext,
-    arg: Arg[Any],
+    arg: FinalArg[Any],
     option: RawOption | None = None,
 ) -> Any:
-    field_name = cast(str, arg.field_name)
+    field_name = arg.field_name
 
     # Determine how many values to collect
-    normalized_num_args = assert_type(arg.num_args, NumArgs)
+    normalized_num_args = arg.num_args
     expected_count = normalized_num_args.n
     if ArgAction.is_non_value_consuming(arg.action):
         expected_count = 0
@@ -706,7 +702,7 @@ def consume_arg(
             field_name,
             normalized_num_args.default,
             option,
-            assert_type(arg.has_value, bool),
+            arg.has_value,
         )
         check_deprecated(parse_state, arg, option)
         return
@@ -733,11 +729,13 @@ def consume_arg(
     resolved_context = context.resolve_context(field_name, option)
 
     fulfilled_deps: dict[Hashable, Any] = {
+        FinalCommand: parse_state.current_command,
         Command: parse_state.current_command,
         Output: parse_state.output,
         ParseContext: resolved_context,
         ParseState: parse_state,
         Arg: arg,
+        FinalArg: arg,
         Value: Value(result),
         Any: result,
     }
@@ -747,16 +745,14 @@ def consume_arg(
     kwargs = fulfill_deps(action_handler, fulfilled_deps).kwargs
     result = action_handler(**kwargs)
 
-    resolved_context.set_result(
-        field_name, result, option, assert_type(arg.has_value, bool)
-    )
+    resolved_context.set_result(field_name, result, option, arg.has_value)
 
     check_deprecated(parse_state, arg, option)
 
 
 def check_deprecated(
     parse_state: ParseState,
-    arg: Arg[Any] | Command[Any],
+    arg: FinalArg[Any] | FinalCommand[Any],
     option: RawOption | None = None,
 ) -> None:
     if not arg.deprecated:

--- a/src/cappa/subcommand.py
+++ b/src/cappa/subcommand.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import TYPE_CHECKING, Any, Iterable, TextIO
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, TextIO
 
-from typing_extensions import Annotated, Self, TypeAlias
+from typing_extensions import Annotated, TypeAlias
 
 from cappa.arg import Group
 from cappa.class_inspect import Field, extract_dataclass_metadata
@@ -14,8 +14,8 @@ from cappa.type_view import Empty, EmptyType, TypeView
 from cappa.typing import T, assert_type, find_annotations
 
 if TYPE_CHECKING:
-    from cappa.arg import Arg
-    from cappa.command import Alias, Command
+    from cappa.arg import FinalArg
+    from cappa.command import Alias, Command, FinalCommand
     from cappa.help import HelpFormattable
     from cappa.output import Output
 
@@ -48,7 +48,7 @@ class Subcommand:
     group: str | tuple[int, str] | Group = DEFAULT_SUBCOMMAND_GROUP
     hidden: bool = False
 
-    options: dict[str, Command[Any]] = dataclasses.field(default_factory=lambda: {})
+    options: Mapping[str, Command[Any]] = dataclasses.field(default_factory=lambda: {})
     types: Iterable[type] | EmptyType = Empty
 
     # Mapping of alias name -> (canonical name in `options`, Alias metadata).
@@ -76,9 +76,9 @@ class Subcommand:
         type_view: TypeView[Any] | None = None,
         field_name: str | None = None,
         help_formatter: HelpFormattable | None = None,
-        propagated_arguments: list[Arg[Any]] | None = None,
+        propagated_arguments: list[FinalArg[Any]] | None = None,
         state: State[Any] | None = None,
-    ) -> Self:
+    ) -> FinalSubcommand:
         if type_view is None:
             type_view = TypeView(Any)
 
@@ -95,8 +95,8 @@ class Subcommand:
         alias_map = build_alias_map(options)
         group = infer_group(self)
 
-        return dataclasses.replace(
-            self,
+        return FinalSubcommand(
+            hidden=self.hidden,
             field_name=field_name,
             types=types,
             required=required,
@@ -104,6 +104,22 @@ class Subcommand:
             alias_map=alias_map,
             group=group,
         )
+
+
+@dataclasses.dataclass
+class FinalSubcommand(Subcommand):
+    """Post-normalization form of :class:`Subcommand` with narrowed field types.
+
+    Produced exclusively by :meth:`Subcommand.normalize`.
+    """
+
+    field_name: str = ""  # pyright: ignore
+    required: bool = False  # pyright: ignore
+    group: Group = dataclasses.field(default_factory=lambda: DEFAULT_SUBCOMMAND_GROUP)  # pyright: ignore
+    types: Iterable[type] = dataclasses.field(default_factory=tuple)  # pyright: ignore
+    options: Mapping[str, FinalCommand[Any]] = dataclasses.field(  # pyright: ignore
+        default_factory=dict
+    )
 
     def resolve_name(self, name: str) -> str | None:
         """Return the canonical name for a typed-in name (canonical or alias).
@@ -131,7 +147,7 @@ class Subcommand:
             option, prog, parsed_args, output=output, state=state, input=input
         )
 
-    def available_options(self) -> list[Command[Any]]:
+    def available_options(self) -> list[FinalCommand[Any]]:
         return [o for o in self.options.values() if not o.hidden]
 
     def names(self) -> list[str]:
@@ -154,7 +170,7 @@ class Subcommand:
         return result
 
     def names_str(self, delimiter: str = ", ") -> str:
-        return f"{delimiter.join(self.names())}"
+        return delimiter.join(self.names())
 
     def completion(self, partial: str):
         return [Completion(o) for o in self.all_visible_names() if partial in o]
@@ -181,34 +197,33 @@ def infer_options(
     arg: Subcommand,
     types: Iterable[type],
     help_formatter: HelpFormattable | None = None,
-    propagated_arguments: list[Arg[Any]] | None = None,
+    propagated_arguments: list[FinalArg[Any]] | None = None,
     state: State[Any] | None = None,
-) -> dict[str, Command[Any]]:
+) -> dict[str, FinalCommand[Any]]:
     from cappa.command import Command
 
     if arg.options:
         return {
-            name: Command.collect(  # pyright: ignore
-                type_command,
+            name: type_command.collect(
                 propagated_arguments=propagated_arguments,
                 state=state,
             )
             for name, type_command in arg.options.items()
         }
 
-    options: dict[str, Command[Any]] = {}
+    options: dict[str, FinalCommand[Any]] = {}
     for type_ in types:
         type_command: Command[Any] = Command.get(type_, help_formatter=help_formatter)  # pyright: ignore
         type_name = type_command.real_name()
-        options[type_name] = Command.collect(  # pyright: ignore
-            type_command, propagated_arguments=propagated_arguments
+        options[type_name] = type_command.collect(
+            propagated_arguments=propagated_arguments
         )
 
     return options
 
 
 def build_alias_map(
-    options: dict[str, Command[Any]],
+    options: dict[str, FinalCommand[Any]],
 ) -> dict[str, tuple[str, Alias]]:
     """Build alias name -> (canonical, Alias) for a set of subcommand options.
 

--- a/src/cappa/types.py
+++ b/src/cappa/types.py
@@ -16,7 +16,7 @@ from typing import (
 from cappa.state import S, State
 
 if TYPE_CHECKING:
-    from cappa.command import Command
+    from cappa.command import Command, FinalCommand
     from cappa.invoke.types import InvokeCallable, Resolved
     from cappa.output import Output
 
@@ -30,7 +30,7 @@ CappaCapable = Union["InvokeCallable[T]", Type[T], "Command[T]"]
 class Backend(Protocol):
     def __call__(
         self,
-        command: Command[T],
+        command: FinalCommand[T],
         argv: list[str],
         output: Output,
         prog: str,

--- a/tests/subcommand/test_aliases.py
+++ b/tests/subcommand/test_aliases.py
@@ -6,6 +6,8 @@ from typing import Any, Union
 import pytest
 
 import cappa
+from cappa.help import HelpFormatter, format_subcommand
+from cappa.subcommand import FinalSubcommand
 from tests.utils import Backend, backends, parse, parse_completion
 
 
@@ -247,15 +249,13 @@ def test_alias_collides_with_other_alias():
 
 def test_visible_aliases_for_unknown_canonical_returns_empty():
     """`visible_aliases_for` returns [] when given a name that isn't a subcommand."""
-    sub = cappa.Subcommand(field_name="cmd", options={})
+    sub = FinalSubcommand(field_name="cmd", options={})
     assert sub.visible_aliases_for("not-a-subcommand") == []
 
 
 def test_format_subcommand_without_subcommand_arg():
     """`format_subcommand` works with the default `subcommand=None`."""
-    from cappa.help import HelpFormatter, format_subcommand
-
-    cmd = cappa.Command(List)
+    cmd = cappa.Command(List).collect()
     padding, help_text = format_subcommand(HelpFormatter(), cmd)
     rendered = str(padding.renderable)
     assert "list" in rendered

--- a/uv.lock
+++ b/uv.lock
@@ -84,7 +84,7 @@ wheels = [
 
 [[package]]
 name = "cappa"
-version = "0.31.1"
+version = "0.32.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
These subclasses have narrowed types which allow all the downstream code to act under the (correct) pretense that the objects have been realized to their **actual** values from the default inferred one provided by the user.