### PR TITLE
fix: Destructured args to inherit `default_long` and `default_short`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fix: Precalculate implicit deps during class construction rather than traversing the output shape.
 - fix: Thread `output` into `parse_result.instance` resolution in `parse`/`parse_async`/`invoke`/`invoke_async`, so `cappa.Exit` raised from `Arg(parse=...)` callbacks renders an error message instead of silently exiting non-zero.
 - refactor: Destructured implementation to be more like Arg handling to fix default and helptext behavior. 
+- fix: Destructured args to inherit `default_long` and `default_short`.
 
 ## 0.31
 

--- a/src/cappa/arg.py
+++ b/src/cappa/arg.py
@@ -522,7 +522,12 @@ class Arg(Generic[T]):
         )
 
         destructure = Destructure.collect(
-            field_name, default, destructure or self.destructure, type_view
+            field_name,
+            default,
+            destructure or self.destructure,
+            type_view,
+            default_short=default_short,
+            default_long=default_long,
         )
         result: FinalArg[Any] = FinalArg(
             # preserved from self

--- a/src/cappa/destructure.py
+++ b/src/cappa/destructure.py
@@ -24,6 +24,8 @@ class Destructure:
         default: Default,
         destructure: Destructure | bool | None,
         type_view: TypeView[Any],
+        default_short: bool = False,
+        default_long: bool = False,
     ) -> FinalDestructure[Any] | None:
         if not destructure:
             return None
@@ -37,7 +39,13 @@ class Destructure:
                 "Destructured arguments currently only support singular concrete types."
             )
 
-        command: FinalCommand[Any] = Command.get(annotation).collect()  # pyright: ignore
+        inner: Command[Any] = Command.get(annotation)  # pyright: ignore
+        inner = replace(
+            inner,
+            default_short=inner.default_short or default_short,
+            default_long=inner.default_long or default_long,
+        )
+        command: FinalCommand[Any] = inner.collect()
         return FinalDestructure(
             field_name=field_name,
             command=command,

--- a/tests/arg/test_destructured_default_long_short.py
+++ b/tests/arg/test_destructured_default_long_short.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import cappa
+from tests.utils import parse
+
+
+@dataclass
+class Args:
+    foo: int = 4
+    bar: int = 5
+
+
+@cappa.command(default_long=True, default_short=True)
+@dataclass
+class Command:
+    args: cappa.Destructured[Args]
+
+
+@cappa.command(default_long=True)
+@dataclass
+class InnerOverrideArgs:
+    foo: int = 4
+
+
+@cappa.command(default_long=False)
+@dataclass
+class InnerOverrideCommand:
+    args: cappa.Destructured[InnerOverrideArgs]
+
+
+def test_default_long_propagates():
+    test = parse(Command, "--foo", "1", "--bar", "2")
+    assert test == Command(Args(1, 2))
+
+
+def test_default_short_propagates():
+    test = parse(Command, "-f", "1", "-b", "2")
+    assert test == Command(Args(1, 2))
+
+
+def test_inner_command_setting_takes_precedence():
+    test = parse(InnerOverrideCommand, "--foo", "1")
+    assert test == InnerOverrideCommand(InnerOverrideArgs(1))


### PR DESCRIPTION
Addresses issue raised in https://github.com/DanCardin/cappa/issues/265