### PR TITLE
Only run the msgspec tests if the msgspec library is installed

### DIFF
--- a/tests/test_msgspec.py
+++ b/tests/test_msgspec.py
@@ -3,29 +3,38 @@ from __future__ import annotations
 import sys
 from typing import Optional
 
+import pytest
 from typing_extensions import Annotated
 
 import cappa
 from tests.utils import Backend, backends, parse
 
 if sys.version_info >= (3, 9):
-    import msgspec
+    try:
+        import msgspec
 
-    class PydanticCommand(msgspec.Struct):
-        name: str
-        foo: Annotated[int, cappa.Arg(short=True)]
+        HAVE_MSGSPEC = True
 
+        class PydanticCommand(msgspec.Struct):
+            name: str
+            foo: Annotated[int, cappa.Arg(short=True)]
+
+        class OptSub(msgspec.Struct):
+            name: Optional[str] = None
+
+        class OptionalSubcommand(msgspec.Struct):
+            sub: cappa.Subcommands[Optional[OptSub]] = None
+
+    except ImportError:
+        HAVE_MSGSPEC = False  # pyright: ignore[reportConstantRedefinition]
+
+    @pytest.mark.skipif(not HAVE_MSGSPEC, reason="msgspec not installed")
     @backends
     def test_base_model(backend: Backend):
         result = parse(PydanticCommand, "meow", "-f", "4", backend=backend)
         assert result == PydanticCommand(name="meow", foo=4)
 
-    class OptSub(msgspec.Struct):
-        name: Optional[str] = None
-
-    class OptionalSubcommand(msgspec.Struct):
-        sub: cappa.Subcommands[Optional[OptSub]] = None
-
+    @pytest.mark.skipif(not HAVE_MSGSPEC, reason="msgspec not installed")
     @backends
     def test_optional_subcommand(backend: Backend):
         result = parse(OptionalSubcommand, backend=backend)


### PR DESCRIPTION
Hi,

First of all, thanks a lot for writing and maintaining cappa!

What do you think about the following change that will make the test suite run even in weird cases when the msgpack library is not available? As explained in the commit message, this can happen if a packaged version of cappa is built in an environment where the corresponding packaging system does not build the msgspec package at all, even though it may build it for other platforms/architectures.

Thanks in advance for looking into this, and keep up the great work!

G'luck,
Peter