### PR TITLE
fix: Negated boolean args rendering default help text in incorrect location.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.32
 
 ### 0.32.2
+- fix: Negated boolean args rendering default help text in incorrect location.
 - fix: Preserve multiline help text formatting.
 - fix: Dedent attribute docstrings' content.
 

--- a/src/cappa/arg.py
+++ b/src/cappa/arg.py
@@ -189,7 +189,10 @@ class NumArgs:
 
         is_positional = arg is None or (not arg.short and not long)
         is_sequence = type_view.is_variadic_tuple or type_view.is_subclass_of(
-            (list, set)
+            (
+                list,
+                set,
+            )
         )
         if is_positional and is_sequence:
             return cls.unbounded()
@@ -924,10 +927,6 @@ def explode_negated_bool_args(
             if negatives and positives:
                 assert isinstance(arg.default, Default)
 
-                not_required = not arg.required
-                show_default = arg.show_default
-                default_is_true = arg.default.fallback_value is True and not_required
-                default_is_false = arg.default.fallback_value is False and not_required
                 disabled: DefaultFormatter = DefaultFormatter.disabled()
                 group = dataclasses.replace(
                     arg.group,
@@ -939,7 +938,7 @@ def explode_negated_bool_args(
                     arg,
                     long=positives,
                     action=ArgAction.store_true,
-                    show_default=show_default if default_is_true else disabled,
+                    show_default=disabled,
                     group=group,
                     help=None,
                 )
@@ -947,7 +946,7 @@ def explode_negated_bool_args(
                     arg,
                     long=negatives,
                     action=ArgAction.store_false,
-                    show_default=show_default if default_is_false else disabled,
+                    show_default=arg.show_default,
                     group=group,
                 )
 

--- a/tests/help/test_bool_help.py
+++ b/tests/help/test_bool_help.py
@@ -24,3 +24,22 @@ def test_default_help(backend: Backend, capsys: Any):
 
     out = CapsysOutput.from_capsys(capsys)
     assert re.match(r".*--no-flag]\s+meow.\s+\(Default", out.stdout, re.DOTALL)
+
+
+@pytest.mark.help
+@backends
+def test_default_help_true_default(backend: Backend, capsys: Any):
+    """Default text must follow help text regardless of whether default is True or False."""
+
+    @cappa.command
+    class TrueDefault:
+        flag: Annotated[bool, cappa.Arg(long=["--flag", "--no-flag"], help="meow.")] = (
+            True
+        )
+
+    with pytest.raises(Exit):
+        parse(TrueDefault, "--help", backend=backend)
+
+    out = CapsysOutput.from_capsys(capsys)
+    assert re.match(r".*--no-flag]\s+meow.\s+\(Default", out.stdout, re.DOTALL)
+    assert "(Default: True)" in out.stdout


### PR DESCRIPTION
Fixes https://github.com/DanCardin/cappa/issues/275